### PR TITLE
Update xmtp rn sdk for logging improvements and stability improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@thirdweb-dev/react-native-adapter": "^1.5.3",
     "@walletconnect/react-native-compat": "^2.19.0",
     "@xmtp/content-type-primitives": "^2.0.0",
-    "@xmtp/react-native-sdk": "4.2.0-dev.09437af",
+    "@xmtp/react-native-sdk": "4.2.0-dev.92e3c0d",
     "@xstate/react": "^5.0.0",
     "@yornaath/batshit": "^0.10.1",
     "alchemy-sdk": "^3.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8807,9 +8807,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/react-native-sdk@npm:4.2.0-dev.09437af":
-  version: 4.2.0-dev.09437af
-  resolution: "@xmtp/react-native-sdk@npm:4.2.0-dev.09437af"
+"@xmtp/react-native-sdk@npm:4.2.0-dev.92e3c0d":
+  version: 4.2.0-dev.92e3c0d
+  resolution: "@xmtp/react-native-sdk@npm:4.2.0-dev.92e3c0d"
   dependencies:
     "@changesets/changelog-git": "npm:^0.2.0"
     "@changesets/cli": "npm:^2.27.10"
@@ -8823,7 +8823,7 @@ __metadata:
     expo: "*"
     react: "*"
     react-native: "*"
-  checksum: 10c0/cee3ac09daed8489d26aa3f0c119d303465204163bda481ba56a72e03fece2e665259d474d63efa5744ce20a95e930143ab082ca6eacaaf8d8d5b3dc9d2379fb
+  checksum: 10c0/d3fd6a4c544b83756e87ba57a36e41aa0330a8032f4478046345ffa293912275437ad8ea9c3929d1de8be4d8854c2fdcf731b76cc8bb896daa1f2f7dc652556f
   languageName: node
   linkType: hard
 
@@ -10732,7 +10732,7 @@ __metadata:
     "@walletconnect/react-native-compat": "npm:^2.19.0"
     "@welldone-software/why-did-you-render": "npm:^8.0.3"
     "@xmtp/content-type-primitives": "npm:^2.0.0"
-    "@xmtp/react-native-sdk": "npm:4.2.0-dev.09437af"
+    "@xmtp/react-native-sdk": "npm:4.2.0-dev.92e3c0d"
     "@xstate/react": "npm:^5.0.0"
     "@yornaath/batshit": "npm:^0.10.1"
     alchemy-sdk: "npm:^3.4.4"


### PR DESCRIPTION
Relevant libxmtp updates in this PR are:

- dont update welcome cursor from stream - https://github.com/xmtp/libxmtp/commit/77e4319c4bd55f070aff69104bf58300f19120b8
- Log improvements - https://github.com/xmtp/libxmtp/commit/bb383c1027727ceb369a3f7683d38aac55de896a
- mark intents as processes instead of deleting them - https://github.com/xmtp/libxmtp/commit/5708561d14b03e499ea8c60198a13a4c1bf76040
