### PR TITLE
Adjust icon sizes, hitslop and paddings in navigation

### DIFF
--- a/design-system/Header/Header.tsx
+++ b/design-system/Header/Header.tsx
@@ -100,10 +100,10 @@ export function Header(props: HeaderProps) {
       >
         <HStack
           // {...debugBorder("red")}
-          style={$contentContainer}
+          style={themed($contentContainer)}
         >
           {onBack ? (
-            <HeaderAction icon="chevron.left" onPress={onBack} backgroundColor={backgroundColor} />
+            <HeaderAction icon="chevron.left" onPress={onBack} />
           ) : (
             (leftTx || leftText || leftIcon || LeftActionComponent) && (
               <HeaderAction
@@ -156,19 +156,19 @@ export function Header(props: HeaderProps) {
 
 const $wrapper: ThemedStyle<ViewStyle> = ({ spacing }) => ({
   alignItems: "center",
-  paddingHorizontal: spacing.xs,
+  paddingHorizontal: spacing.xxs,
 })
 
 const $container: ViewStyle = {
   width: "100%",
 }
 
-const $contentContainer: ViewStyle = {
+const $contentContainer: ThemedStyle<ViewStyle> = ({ spacing }) => ({
   flex: 1,
   alignItems: "center",
-}
+})
 
-const $titleContainer: ThemedStyle<ViewStyle> = () => ({
+const $titleContainer: ThemedStyle<ViewStyle> = ({ spacing }) => ({
   alignItems: "center",
   justifyContent: "center",
   zIndex: 1,

--- a/design-system/Header/HeaderAction.tsx
+++ b/design-system/Header/HeaderAction.tsx
@@ -64,7 +64,7 @@ export function HeaderAction(props: HeaderActionProps) {
         style={[themed([$actionIconContainer, { backgroundColor }]), style, disabledStyle]}
         hitSlop={theme.spacing.xxxs}
       >
-        <Icon size={theme.iconSize.lg} icon={icon} color={iconColor} />
+        <Icon size={theme.iconSize.md} icon={icon} color={iconColor} />
       </Pressable>
     )
   }

--- a/design-system/Icon/Icon.tsx
+++ b/design-system/Icon/Icon.tsx
@@ -86,7 +86,7 @@ export function Icon(props: IIconProps) {
     picto,
     icon,
     style,
-    size = theme.iconSize.lg,
+    size = theme.iconSize.md,
     color = theme.colors.fill.primary,
     weight,
     ...rest

--- a/features/conversation/conversation-chat/conversation.screen-header.tsx
+++ b/features/conversation/conversation-chat/conversation.screen-header.tsx
@@ -152,6 +152,7 @@ const ConversationHeaderTitleDumb = memo(function ConversationHeaderTitle({
   return (
     <HStack
       style={{
+        paddingHorizontal: theme.spacing.xxxs,
         flex: 1,
       }}
     >

--- a/features/conversation/conversation-list/conversation-list.screen-header.tsx
+++ b/features/conversation/conversation-list/conversation-list.screen-header.tsx
@@ -50,7 +50,7 @@ function HeaderRightActions() {
 
 const $rightContainer: ThemedStyle<ViewStyle> = (theme) => ({
   alignItems: "center",
-  columnGap: theme.spacing.xxs,
+  columnGap: theme.spacing.xxxs,
 })
 
 const $newConversationContainer: ViewStyle = {


### PR DESCRIPTION
### Reduce header icon sizes from large to medium and adjust header component paddings to improve navigation layout
* Updates icon sizing from `lg` to `md` in [HeaderAction.tsx](https://github.com/ephemeraHQ/convos-app/pull/29/files#diff-f533cd0b72448649d83e7a5aa73cab78e8201181500dbbad47530fd54075a858) and [Icon.tsx](https://github.com/ephemeraHQ/convos-app/pull/29/files#diff-8c2038fce3bd74bee38a149f5544c160990e897516826f5cfbcc93efd0d45bc2)
* Modifies padding in [Header.tsx](https://github.com/ephemeraHQ/convos-app/pull/29/files#diff-a5c17945194458fc61d462daa344bd5d32334534d6f7b484a5678a31c5720532) from `spacing.xs` to `spacing.xxs` and implements themed styling for content container
* Adds `xxxs` horizontal padding to conversation header in [conversation.screen-header.tsx](https://github.com/ephemeraHQ/convos-app/pull/29/files#diff-bd0ebfd3fb2ad6b3a492525907e2ab67c8911a65f82144b1cdb2a157e9ac4441)

#### 📍Where to Start
Start with the icon size changes in [HeaderAction.tsx](https://github.com/ephemeraHQ/convos-app/pull/29/files#diff-f533cd0b72448649d83e7a5aa73cab78e8201181500dbbad47530fd54075a858) and [Icon.tsx](https://github.com/ephemeraHQ/convos-app/pull/29/files#diff-8c2038fce3bd74bee38a149f5544c160990e897516826f5cfbcc93efd0d45bc2), as these represent the core functional changes that affect the navigation appearance.

----

_[Macroscope](https://app.macroscope.com) summarized 4975a56._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Adjusted header and icon sizing for a more compact appearance.
	- Reduced horizontal padding in the header for a tighter layout.
	- Updated default icon size from large to medium for consistency.
	- Added subtle horizontal padding to the conversation header title area.
	- Reduced spacing between elements in the conversation list screen header for a cleaner look.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->