### PR TITLE
fix: pass `clientInboxId` when setting XMTP consent state

### DIFF
--- a/features/consent/use-deny-dm.mutation.ts
+++ b/features/consent/use-deny-dm.mutation.ts
@@ -34,6 +34,7 @@ export function useDenyDmMutation() {
         }),
         setXmtpConsentStateForInboxId({
           peerInboxId,
+          clientInboxId: currentSenderInboxId,
           consent: "denied",
         }),
       ])

--- a/features/consent/use-deny-dm.mutation.ts
+++ b/features/consent/use-deny-dm.mutation.ts
@@ -34,7 +34,6 @@ export function useDenyDmMutation() {
         }),
         setXmtpConsentStateForInboxId({
           peerInboxId,
-          clientInboxId: currentSenderInboxId,
           consent: "denied",
         }),
       ])

--- a/features/xmtp/xmtp-consent/xmtp-consent.ts
+++ b/features/xmtp/xmtp-consent/xmtp-consent.ts
@@ -3,6 +3,7 @@ import { getXmtpClientByInboxId } from "@/features/xmtp/xmtp-client/xmtp-client"
 import { wrapXmtpCallWithDuration } from "@/features/xmtp/xmtp.helpers"
 import { XMTPError } from "@/utils/error"
 import { IEthereumAddress } from "@/utils/evm/address"
+import { useMultiInboxStore } from "@/features/authentication/multi-inbox.store"
 
 export async function xmtpInboxIdCanMessageEthAddress(args: {
   inboxId: IXmtpInboxId
@@ -65,14 +66,21 @@ export async function xmtpInboxIdCanMessageEthAddress(args: {
 
 export async function setXmtpConsentStateForInboxId(args: {
   peerInboxId: IXmtpInboxId
-  clientInboxId: IXmtpInboxId
   consent: IXmtpConsentState
 }) {
-  const { peerInboxId, clientInboxId, consent } = args
+  const { peerInboxId, consent } = args
+  const currentSenderInboxId = useMultiInboxStore.getState().currentSender?.inboxId
+
+  if (!currentSenderInboxId) {
+    throw new XMTPError({
+      error: new Error("No current sender found"),
+      additionalMessage: "failed to set XMTP consent state for inboxId",
+    })
+  }
 
   try {
     const client = await getXmtpClientByInboxId({
-      inboxId: clientInboxId,
+      inboxId: currentSenderInboxId,
     })
 
     await wrapXmtpCallWithDuration("setConsentState", () =>

--- a/features/xmtp/xmtp-consent/xmtp-consent.ts
+++ b/features/xmtp/xmtp-consent/xmtp-consent.ts
@@ -65,13 +65,14 @@ export async function xmtpInboxIdCanMessageEthAddress(args: {
 
 export async function setXmtpConsentStateForInboxId(args: {
   peerInboxId: IXmtpInboxId
+  clientInboxId: IXmtpInboxId
   consent: IXmtpConsentState
 }) {
-  const { peerInboxId, consent } = args
+  const { peerInboxId, clientInboxId, consent } = args
 
   try {
     const client = await getXmtpClientByInboxId({
-      inboxId: peerInboxId,
+      inboxId: clientInboxId,
     })
 
     await wrapXmtpCallWithDuration("setConsentState", () =>


### PR DESCRIPTION
Use current user's inbox ID instead of peer's inbox ID to get XMTP client when denying/deleting a message request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy when denying direct message consent by ensuring the correct inbox is referenced during the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->