### PR TITLE
feat(deep-linking): add support for app scheme in deep links

### DIFF
--- a/features/deep-linking/link-parser.ts
+++ b/features/deep-linking/link-parser.ts
@@ -1,4 +1,8 @@
 import { logger } from "@/utils/logger/logger"
+import Constants from "expo-constants"
+
+// Get the app scheme from Expo constants (e.g. "convos-dev")
+const APP_SCHEME = Constants.expoConfig?.scheme as string
 
 /**
  * Deep link URL parsing
@@ -15,8 +19,18 @@ export function parseURL(url: string) {
     const parsedURL = new URL(url)
     logger.info(`Parsing deep link URL: ${url}`)
 
+    // Check if this is our app scheme
+    // URL protocol includes colon (e.g. "convos-dev:") while our APP_SCHEME is just "convos-dev"
+    const urlProtocol = `${APP_SCHEME}:`
+    const isAppScheme = parsedURL.protocol === urlProtocol
+    
     // Extract the path without leading slash
-    const path = parsedURL.pathname.replace(/^\/+/, "")
+    let path = parsedURL.pathname.replace(/^\/+/, "")
+    
+    // For app scheme URLs, include the host as the first path segment
+    if (isAppScheme && parsedURL.host) {
+      path = parsedURL.host + (path ? '/' + path : '')
+    }
 
     // Split path into segments
     const segments = path.split("/").filter(Boolean)


### PR DESCRIPTION
This change allows the app to respond to both web links `https://convos.org/dm/[inboxId]` and app scheme links `convos://conversation/[inboxId]` on iOS.

- Add pattern handler for "convos://dm/:inboxId" deep links
- Refactor duplicate code into a shared conversation link handler function
- Update URL parser to correctly handle app scheme deep links
- Use app scheme from Expo constants instead of hardcoded values
- Improve error handling and logging