### PR TITLE
refactor: require `clientInboxId` in args for XMTP consent function

### DIFF
--- a/features/consent/use-allow-dm.mutation.ts
+++ b/features/consent/use-allow-dm.mutation.ts
@@ -33,6 +33,7 @@ export function useAllowDmMutation() {
         setXmtpConsentStateForInboxId({
           peerInboxId: currentSenderInboxId,
           consent: "allowed",
+          clientInboxId: currentSenderInboxId,
         }),
       ])
     },

--- a/features/consent/use-allow-group.mutation.ts
+++ b/features/consent/use-allow-group.mutation.ts
@@ -79,6 +79,7 @@ async function allowGroup({
           setXmtpConsentStateForInboxId({
             peerInboxId: clientInboxId,
             consent: "allowed",
+            clientInboxId,
           }),
         ]
       : []),

--- a/features/consent/use-deny-dm.mutation.ts
+++ b/features/consent/use-deny-dm.mutation.ts
@@ -35,6 +35,7 @@ export function useDenyDmMutation() {
         setXmtpConsentStateForInboxId({
           peerInboxId,
           consent: "denied",
+          clientInboxId: currentSenderInboxId,
         }),
       ])
     },

--- a/features/consent/use-group-consent-for-current-sender.ts
+++ b/features/consent/use-group-consent-for-current-sender.ts
@@ -7,7 +7,6 @@ import { useDenyGroupMutation } from "@/features/consent/use-deny-group.mutation
 import { getGroupQueryOptions, useGroupQuery } from "@/features/groups/queries/group.query"
 import { translate } from "@/i18n"
 import { useSafeCurrentSender } from "../authentication/multi-inbox.store"
-import { IConversationTopic } from "../conversation/conversation.types"
 import { setXmtpConsentStateForInboxId } from "../xmtp/xmtp-consent/xmtp-consent"
 
 export type IGroupConsentOptions = {
@@ -98,12 +97,13 @@ export const useGroupConsentForCurrentSender = (args: {
             setXmtpConsentStateForInboxId({
               peerInboxId: inboxId,
               consent: "denied",
+              clientInboxId: currentSender.inboxId,
             }),
           ),
         )
       }
     },
-    [denyGroupMutation, group],
+    [denyGroupMutation, group, currentSender],
   )
 
   const isLoading = isGroupLoading || isGroupConsentLoading

--- a/features/xmtp/xmtp-consent/xmtp-consent.ts
+++ b/features/xmtp/xmtp-consent/xmtp-consent.ts
@@ -3,7 +3,6 @@ import { getXmtpClientByInboxId } from "@/features/xmtp/xmtp-client/xmtp-client"
 import { wrapXmtpCallWithDuration } from "@/features/xmtp/xmtp.helpers"
 import { XMTPError } from "@/utils/error"
 import { IEthereumAddress } from "@/utils/evm/address"
-import { useMultiInboxStore } from "@/features/authentication/multi-inbox.store"
 
 export async function xmtpInboxIdCanMessageEthAddress(args: {
   inboxId: IXmtpInboxId
@@ -67,20 +66,13 @@ export async function xmtpInboxIdCanMessageEthAddress(args: {
 export async function setXmtpConsentStateForInboxId(args: {
   peerInboxId: IXmtpInboxId
   consent: IXmtpConsentState
+  clientInboxId: IXmtpInboxId
 }) {
-  const { peerInboxId, consent } = args
-  const currentSenderInboxId = useMultiInboxStore.getState().currentSender?.inboxId
-
-  if (!currentSenderInboxId) {
-    throw new XMTPError({
-      error: new Error("No current sender found"),
-      additionalMessage: "failed to set XMTP consent state for inboxId",
-    })
-  }
+  const { peerInboxId, consent, clientInboxId } = args
 
   try {
     const client = await getXmtpClientByInboxId({
-      inboxId: currentSenderInboxId,
+      inboxId: clientInboxId,
     })
 
     await wrapXmtpCallWithDuration("setConsentState", () =>


### PR DESCRIPTION
Linked to: https://github.com/ephemeraHQ/convos-app/pull/32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of consent management by ensuring the correct inbox ID is always used when updating consent states for direct messages and groups.
- **Refactor**
  - Streamlined internal consent handling to require explicit inbox identification, enhancing maintainability and reducing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->