### PR TITLE
Change span op name

### DIFF
--- a/features/xmtp/xmtp.helpers.ts
+++ b/features/xmtp/xmtp.helpers.ts
@@ -49,7 +49,13 @@ export async function wrapXmtpCallWithDuration<T>(
     xmtpLogger.debug(`XMTP operation [${operationId}] "${xmtpFunctionName}" started...`)
 
     // track the XMTP call with Sentry
-    const xmtpSpanCall = Sentry.startSpan({ name: xmtpFunctionName }, () => xmtpCall())
+    const xmtpSpanCall = Sentry.startSpan(
+      {
+        name: xmtpFunctionName,
+        op: "XMTP",
+      },
+      () => xmtpCall(),
+    )
 
     // Execute the actual XMTP call with a 15-second timeout
     const result = await withTimeout({


### PR DESCRIPTION
### Add 'XMTP' operation type to Sentry span tracking in `wrapXmtpCallWithDuration` function
The `wrapXmtpCallWithDuration` function in [xmtp.helpers.ts](https://github.com/ephemeraHQ/convos-app/pull/38/files#diff-9afbfca526162128d55eb768d0770f843533980490ccf50f4e60377b35c010b0) now includes an operation type parameter `op: "XMTP"` in the `Sentry.startSpan` configuration for more granular span categorization.

#### 📍Where to Start
Begin reviewing the `wrapXmtpCallWithDuration` function in [xmtp.helpers.ts](https://github.com/ephemeraHQ/convos-app/pull/38/files#diff-9afbfca526162128d55eb768d0770f843533980490ccf50f4e60377b35c010b0) where the Sentry span configuration has been modified.

----

_[Macroscope](https://app.macroscope.com) summarized 42fc0fa._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved internal monitoring by enhancing span metadata for XMTP operations. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->