### PR TITLE
fix: from profile, navigate to existing convo if it exists

### DIFF
--- a/features/deep-linking/vanity-url-handler.test.ts
+++ b/features/deep-linking/vanity-url-handler.test.ts
@@ -8,6 +8,7 @@ jest.mock("@/config", () => ({
   config: {
     app: {
       webDomain: "convos.org",
+      apiUrl: "https://api.test.convos.org",
     },
   },
 }))
@@ -17,6 +18,12 @@ jest.mock("@/navigation/navigation.utils")
 jest.mock("@/utils/logger/logger", () => {
   return {
     deepLinkLogger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+    apiLogger: {
+      debug: jest.fn(),
       info: jest.fn(),
       warn: jest.fn(),
       error: jest.fn(),


### PR DESCRIPTION
### Navigate to existing conversations from profile screen by checking for conversations between users before creating new ones in `handleChatPress` function
The `handleChatPress` function in [profile-other.screen-header.tsx](https://github.com/ephemeraHQ/convos-app/pull/41/files#diff-e758a01a3f6a1f1716cb3070814578a037ac5c77fa0cd2d07b4fcc92dc224da8) has been modified to check for existing conversations between users. The function now:

* Retrieves current sender's inbox ID using `useCurrentSender`
* Uses `findConversationByInboxIds` to check for existing conversations
* Implements error handling with `captureError` and `GenericError`
* Falls back to creating new conversation if none exists or on error

#### 📍Where to Start
Start with the `handleChatPress` function in [profile-other.screen-header.tsx](https://github.com/ephemeraHQ/convos-app/pull/41/files#diff-e758a01a3f6a1f1716cb3070814578a037ac5c77fa0cd2d07b4fcc92dc224da8), which contains the main logic for finding and navigating to existing conversations.

----

_[Macroscope](https://app.macroscope.com) summarized 13ea004._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved chat initiation by reusing existing conversations when available, reducing duplicate conversation threads.

- **Bug Fixes**
  - Enhanced error handling during chat initiation to ensure a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->