### PR TITLE
fix: remove messages from logs

### DIFF
--- a/features/notifications/notifications-init.ts
+++ b/features/notifications/notifications-init.ts
@@ -162,8 +162,7 @@ async function maybeDisplayLocalNewMessageNotification(args: {
 
   if (!isSupportedXmtpMessage(xmtpDecryptedMessage)) {
     notificationsLogger.debug(
-      `Skipping notification because message is not supported`,
-      xmtpDecryptedMessage,
+      `Skipping notification because message is not supported`
     )
     return
   }

--- a/features/streams/stream-messages.ts
+++ b/features/streams/stream-messages.ts
@@ -48,8 +48,6 @@ async function handleNewMessage(args: {
 }) {
   const { clientInboxId, message } = args
 
-  streamLogger.debug(`New message:`, message)
-
   // Process reaction messages
   if (isReactionMessage(message)) {
     processReactionConversationMessages({ clientInboxId, reactionMessages: [message] })

--- a/features/xmtp/xmtp-messages/xmtp-messages-stream.ts
+++ b/features/xmtp/xmtp-messages/xmtp-messages-stream.ts
@@ -19,7 +19,7 @@ export const streamAllMessages = async (args: {
     // Not wrapping the stream initiation itself as it's long-running
     await client.conversations.streamAllMessages((newMessage) => {
       if (!isSupportedXmtpMessage(newMessage)) {
-        xmtpLogger.debug(`Skipping message streamed because it's not supported`, newMessage)
+        xmtpLogger.debug(`Skipping message streamed because it's not supported`)
         return Promise.resolve()
       }
       return onNewMessage(newMessage)


### PR DESCRIPTION
### Remove message object logging from debug statements in notification and message handling systems
Removes verbose message object logging from debug statements across three files:
* [notifications-init.ts](https://github.com/ephemeraHQ/convos-app/pull/43/files#diff-683db29d1059e50d8f77293f64a7068a81fd78f4d37c547105f1a452ba5dbb41) - Removes `xmtpDecryptedMessage` object from 'Skipping notification' debug log
* [stream-messages.ts](https://github.com/ephemeraHQ/convos-app/pull/43/files#diff-097c98233d2931bc51e8c5cafc88e88c834c2a39556c9f2dc842dbd614d318ee) - Removes 'New message' debug log with message object from `handleNewMessage` function
* [xmtp-messages-stream.ts](https://github.com/ephemeraHQ/convos-app/pull/43/files#diff-7b3e209a2d3b2088f95d8bb9dca4064dd009916193c59159416dc779ae28d9c1) - Removes `newMessage` object from 'Skipping message' debug log

#### 📍Where to Start
Start with the `handleNewMessage` function in [stream-messages.ts](https://github.com/ephemeraHQ/convos-app/pull/43/files#diff-097c98233d2931bc51e8c5cafc88e88c834c2a39556c9f2dc842dbd614d318ee) as it contains the complete removal of a debug statement rather than just parameter modification.

----

_[Macroscope](https://app.macroscope.com) summarized dcf7482._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Reduced the amount of debug logging related to unsupported and new messages, resulting in cleaner logs and improved privacy for message content. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->