### PR TITLE
fix: don't show notifications when app is in foreground

### DIFF
--- a/features/notifications/notifications-init.ts
+++ b/features/notifications/notifications-init.ts
@@ -1,5 +1,5 @@
 import * as Notifications from "expo-notifications"
-import { AppState, Platform } from "react-native"
+import { Platform } from "react-native"
 import { getCurrentSender } from "@/features/authentication/multi-inbox.store"
 import { setConversationMessageQueryData } from "@/features/conversation/conversation-chat/conversation-message/conversation-message.query"
 import {
@@ -20,6 +20,7 @@ import { isSupportedXmtpMessage } from "@/features/xmtp/xmtp-messages/xmtp-messa
 import { captureError } from "@/utils/capture-error"
 import { NotificationError } from "@/utils/error"
 import { notificationsLogger } from "@/utils/logger/logger"
+import { useAppStateStore } from "@/stores/use-app-state-store"
 
 export function configureForegroundNotificationBehavior() {
   Notifications.setNotificationHandler({
@@ -190,12 +191,9 @@ async function maybeDisplayLocalNewMessageNotification(args: {
   })
 
   // Don't show notifications when app is in foreground
-  const appState = AppState.currentState
+  const appState = useAppStateStore.getState().currentState
   if (appState === 'active') {
-    notificationsLogger.debug("App is in foreground (active state), don't display local notification")
     return
-  } else {
-    notificationsLogger.debug(`App is not in foreground (${appState}), display local notification`)
   }
 
   await Notifications.scheduleNotificationAsync({


### PR DESCRIPTION
### Suppress notifications when app is in foreground state by modifying notification display logic in `notifications-init.ts`
Modifies notification display logic in [notifications-init.ts](https://github.com/ephemeraHQ/convos-app/pull/47/files#diff-683db29d1059e50d8f77293f64a7068a81fd78f4d37c547105f1a452ba5dbb41) to use React Native's `AppState` instead of route-based checks. The code now checks if the app is in an 'active' state rather than comparing specific conversation routes, and includes logging for foreground/background state transitions.

#### 📍Where to Start
Start with the notification display logic modifications in [notifications-init.ts](https://github.com/ephemeraHQ/convos-app/pull/47/files#diff-683db29d1059e50d8f77293f64a7068a81fd78f4d37c547105f1a452ba5dbb41), which now uses `AppState.currentState` to determine when to show notifications.

----

_[Macroscope](https://app.macroscope.com) summarized 92829fc._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved notification behavior by suppressing new message notifications when the app is active, regardless of the current screen.
	- Notifications will now only appear when the app is in the background or inactive, reducing unnecessary interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->