### PR TITLE
fix: Removes the default 30-day period for disappearing messages, copy update

### DIFF
--- a/features/conversation/conversation-chat/conversation-message/conversation-message-group-update.tsx
+++ b/features/conversation/conversation-chat/conversation-message/conversation-message-group-update.tsx
@@ -152,7 +152,9 @@ function ChatGroupMetadataUpdate({
       const newValue = parseInt(metadataEntry.newValue, 10)
       const newTime = getFormattedDisappearingDuration(newValue)
 
-      if (metadataEntry.oldValue === "0") {
+      if (newValue === 0) {
+        updateMessage = `disabled disappearing messages`
+      } else if (metadataEntry.oldValue === "0") {
         updateMessage = `set messages to disappear in ${newTime}`
       } else {
         const oldValue = parseInt(metadataEntry.oldValue, 10)

--- a/features/conversation/conversation-create/mutations/create-conversation-and-send-first-message.mutation.ts
+++ b/features/conversation/conversation-create/mutations/create-conversation-and-send-first-message.mutation.ts
@@ -46,14 +46,18 @@ export async function createConversationAndSendFirstMessage(
           await createXmtpGroup({
             clientInboxId: currentSender.inboxId,
             inboxIds,
-            disappearingMessageSettings: defaultConversationDisappearingMessageSettings,
+            ...(defaultConversationDisappearingMessageSettings.retentionDurationInNs > 0 && {
+              disappearingMessageSettings: defaultConversationDisappearingMessageSettings,
+            }),
           }),
         )
       : await convertXmtpConversationToConvosConversation(
           await createXmtpDm({
             senderClientInboxId: currentSender.inboxId,
             peerInboxId: inboxIds[0],
-            disappearingMessageSettings: defaultConversationDisappearingMessageSettings,
+            ...(defaultConversationDisappearingMessageSettings.retentionDurationInNs > 0 && {
+              disappearingMessageSettings: defaultConversationDisappearingMessageSettings,
+            }),
           }),
         )
 

--- a/features/disappearing-messages/disappearing-messages.constants.ts
+++ b/features/disappearing-messages/disappearing-messages.constants.ts
@@ -1,4 +1,3 @@
-import { XMTP_DISAPPEARING_MESSAGE_NO_VALUE_DEFAULT_DURATION_IN_NS } from "@/features/xmtp/xmtp-disappearing-messages/xmtp-disappearing-messages"
 import { getTodayNs } from "@/utils/date"
 import { TimeUtils } from "@/utils/time.utils"
 
@@ -24,15 +23,15 @@ export type IDisappearingMessageSettings = {
 
 export const defaultConversationDisappearingMessageSettings: IDisappearingMessageSettings = {
   disappearStartingAtNs: getTodayNs(),
-  retentionDurationInNs: DisappearingMessageDuration.THIRTY_DAYS.value,
+  retentionDurationInNs: 0,
 }
 
 /**
  * Get a formatted display value for a disappearing message duration in nanoseconds
  */
 export function getFormattedDisappearingDuration(nanoseconds: number | undefined): string {
-  if (!nanoseconds) {
-    nanoseconds = XMTP_DISAPPEARING_MESSAGE_NO_VALUE_DEFAULT_DURATION_IN_NS
+  if (!nanoseconds || nanoseconds === 0) {
+    return "off";
   }
 
   // First check if this matches one of our predefined durations

--- a/features/xmtp/xmtp-disappearing-messages/xmtp-disappearing-messages.ts
+++ b/features/xmtp/xmtp-disappearing-messages/xmtp-disappearing-messages.ts
@@ -9,10 +9,6 @@ import { wrapXmtpCallWithDuration } from "@/features/xmtp/xmtp.helpers"
 import { IXmtpConversationId, IXmtpInboxId } from "@/features/xmtp/xmtp.types"
 import { getTodayNs } from "@/utils/date"
 import { XMTPError } from "@/utils/error"
-import { TimeUtils } from "@/utils/time.utils"
-
-export const XMTP_DISAPPEARING_MESSAGE_NO_VALUE_DEFAULT_DURATION_IN_NS =
-  TimeUtils.days(60).toNanoseconds()
 
 /**
  * Get the current disappearing message settings for a conversation


### PR DESCRIPTION
### Remove default 30-day period for disappearing messages by setting default retention duration to 0 in XMTP conversations
Updates the handling of disappearing messages across multiple components:

* Changes default retention duration from 30 days to 0 (disabled) in [disappearing-messages.constants.ts](https://github.com/ephemeraHQ/convos-app/pull/48/files#diff-5cbc6249b13d16427199d962a3ee4fa848dfaea37b00c68210867cc8da56342c)
* Modifies conversation creation to only include disappearing message settings when retention duration is greater than 0 in [create-conversation-and-send-first-message.mutation.ts](https://github.com/ephemeraHQ/convos-app/pull/48/files#diff-9e39214a38172b0a876dac27a794f0b50d943e5e29c42ec461b9017f168ed1c0)
* Updates message display logic to show 'disabled disappearing messages' when `newValue` is 0 in [conversation-message-group-update.tsx](https://github.com/ephemeraHQ/convos-app/pull/48/files#diff-66ab4676af70597d6fd78cb834bf996107b41ff73d448b4ee6ea6459f8b3093a)
* Removes `XMTP_DISAPPEARING_MESSAGE_NO_VALUE_DEFAULT_DURATION_IN_NS` constant from [xmtp-disappearing-messages.ts](https://github.com/ephemeraHQ/convos-app/pull/48/files#diff-9e7cead05c038c03334129b4a8e220dfa14287c04ca93a688afc69a2fd76595a)

#### 📍Where to Start
Start with the default settings modification in [disappearing-messages.constants.ts](https://github.com/ephemeraHQ/convos-app/pull/48/files#diff-5cbc6249b13d16427199d962a3ee4fa848dfaea37b00c68210867cc8da56342c) as it contains the core changes to the default behavior.

----

_[Macroscope](https://app.macroscope.com) summarized 5072f4d._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Disappearing message settings now clearly indicate when the feature is turned off, displaying "off" for disabled durations.
- **Bug Fixes**
  - Update messages now accurately reflect when disappearing messages are disabled or when their duration changes.
- **Chores**
  - Default disappearing message duration is now set to zero instead of a fixed period.
  - Unused constants and imports related to default duration values have been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->