### PR TITLE
Update to xmtp rn sdk 4.2.0-rc2

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@turnkey/viem": "^0.9.0",
     "@walletconnect/react-native-compat": "^2.19.0",
     "@xmtp/content-type-primitives": "^2.0.0",
-    "@xmtp/react-native-sdk": "4.2.0-dev.73f1217",
+    "@xmtp/react-native-sdk": "4.2.0-rc2",
     "@xstate/react": "^5.0.0",
     "@yornaath/batshit": "^0.10.1",
     "alchemy-sdk": "^3.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9007,9 +9007,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/react-native-sdk@npm:4.2.0-dev.73f1217":
-  version: 4.2.0-dev.73f1217
-  resolution: "@xmtp/react-native-sdk@npm:4.2.0-dev.73f1217"
+"@xmtp/react-native-sdk@npm:4.2.0-rc2":
+  version: 4.2.0-rc2
+  resolution: "@xmtp/react-native-sdk@npm:4.2.0-rc2"
   dependencies:
     "@changesets/changelog-git": "npm:^0.2.0"
     "@changesets/cli": "npm:^2.27.10"
@@ -9018,13 +9018,12 @@ __metadata:
     "@noble/hashes": "npm:^1.3.3"
     "@xmtp/proto": "npm:3.54.0"
     buffer: "npm:^6.0.3"
-    react-native-performance: "npm:^5.1.2"
     text-encoding: "npm:^0.7.0"
   peerDependencies:
     expo: "*"
     react: "*"
     react-native: "*"
-  checksum: 10c0/e889a618074076ad2c7df50fdc0cc068948662711af9fbb6042d676fcd11473579f5707c255080160a038430bc4a8de9ea727f5b38d27cbf80a8fda105685ded
+  checksum: 10c0/751a3b09a2f148c3f99cf5baca8ac8a4f74d2966bae0e6497be903d29ef7b58e3d156471754cc504aef021180ccb69fe3ab0f333567de099cb2590d6d5732b5d
   languageName: node
   linkType: hard
 
@@ -11032,7 +11031,7 @@ __metadata:
     "@walletconnect/react-native-compat": "npm:^2.19.0"
     "@welldone-software/why-did-you-render": "npm:^8.0.3"
     "@xmtp/content-type-primitives": "npm:^2.0.0"
-    "@xmtp/react-native-sdk": "npm:4.2.0-dev.73f1217"
+    "@xmtp/react-native-sdk": "npm:4.2.0-rc2"
     "@xstate/react": "npm:^5.0.0"
     "@yornaath/batshit": "npm:^0.10.1"
     alchemy-sdk: "npm:^3.4.4"
@@ -19990,15 +19989,6 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10c0/8ee9a4a63546f92fabd513d38ad0aa02f1e20f3dddfdcafd9356331c0ea77b39e2abe4ca5a26fd5140958e50c10248578930ca21f7169ce702b0693f612eb6c4
-  languageName: node
-  linkType: hard
-
-"react-native-performance@npm:^5.1.2":
-  version: 5.1.2
-  resolution: "react-native-performance@npm:5.1.2"
-  peerDependencies:
-    react-native: "*"
-  checksum: 10c0/a23ad91c5547e0dc62fcdad0230ebd58c8dcfee236174fd2802da14ca3e97451afdba957a9d258e962cfbc4b1671d672547827e096a440ae36b4e967e4a49f50
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Verified preview app build on local device
- gh action looks to be [manual only for prod release](https://github.com/ephemeraHQ/convos-app/blob/15c513d81f5cbf6e30c8ad4e9acafd7e9fcad806/.github/workflows/production-deployment.yml#L3-L4), so [merging to main should only publish a preview build](https://github.com/ephemeraHQ/convos-app/blob/15c513d81f5cbf6e30c8ad4e9acafd7e9fcad806/.github/workflows/preview-deployment.yml#L3-L14)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of an internal dependency to a newer release candidate for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->