### PR TITLE
feat: show initiator/inviter profile in group chat update messages

### DIFF
--- a/features/conversation/conversation-chat/conversation-message/conversation-message-group-update.tsx
+++ b/features/conversation/conversation-chat/conversation-message/conversation-message-group-update.tsx
@@ -40,7 +40,7 @@ export function ConversationMessageGroupUpdate({ message }: IConversationMessage
         <ChatGroupMemberJoined
           key={`joined-${member.inboxId}`}
           inboxId={member.inboxId as IXmtpInboxId}
-          invitedByInboxId={content.initiatedByInboxId as IXmtpInboxId}
+          initiatedByInboxId={content.initiatedByInboxId as IXmtpInboxId}
         />
       ))}
 
@@ -95,18 +95,18 @@ function ChatGroupMemberLeft({ inboxId }: IChatGroupMemberLeftProps) {
 
 type IChatGroupMemberJoinedProps = {
   inboxId: IXmtpInboxId
-  invitedByInboxId: IXmtpInboxId
+  initiatedByInboxId: IXmtpInboxId
 }
 
-function ChatGroupMemberJoined({ inboxId, invitedByInboxId }: IChatGroupMemberJoinedProps) {
+function ChatGroupMemberJoined({ inboxId, initiatedByInboxId }: IChatGroupMemberJoinedProps) {
   const { themed, theme } = useAppTheme()
   const { displayName, avatarUrl } = usePreferredDisplayInfo({
     inboxId,
     caller: "ChatGroupMemberJoined",
   })
 
-  const { displayName: invitedByDisplayName, avatarUrl: invitedByAvatarUrl } = usePreferredDisplayInfo({
-    inboxId: invitedByInboxId,
+  const { displayName: initiatorDisplayName, avatarUrl: initiatorAvatarUrl } = usePreferredDisplayInfo({
+    inboxId: initiatedByInboxId,
     caller: "ChatGroupMemberJoined",
   })
 
@@ -126,18 +126,18 @@ function ChatGroupMemberJoined({ inboxId, invitedByInboxId }: IChatGroupMemberJo
       <ChatGroupUpdateText>was invited</ChatGroupUpdateText>
 
       {/* Show inviter if their displayName is available */}
-      {invitedByDisplayName && (
+      {initiatorDisplayName && (
         <Pressable
           onPress={() => {
             navigate("Profile", {
-              inboxId: invitedByInboxId,
+              inboxId: initiatedByInboxId,
             })
           }}
         style={themed($pressableContent)}
       >
           <ChatGroupUpdateText>by</ChatGroupUpdateText>
-          <Avatar sizeNumber={theme.avatarSize.xs} uri={invitedByAvatarUrl} name={invitedByDisplayName ?? ""} />
-          <ChatGroupUpdateText weight="bold">{invitedByDisplayName ?? ""}</ChatGroupUpdateText>
+          <Avatar sizeNumber={theme.avatarSize.xs} uri={initiatorAvatarUrl} name={initiatorDisplayName ?? ""} />
+          <ChatGroupUpdateText weight="bold">{initiatorDisplayName ?? ""}</ChatGroupUpdateText>
         </Pressable>
       )}
     </HStack>

--- a/features/conversation/conversation-chat/conversation-message/conversation-message-group-update.tsx
+++ b/features/conversation/conversation-chat/conversation-message/conversation-message-group-update.tsx
@@ -40,6 +40,7 @@ export function ConversationMessageGroupUpdate({ message }: IConversationMessage
         <ChatGroupMemberJoined
           key={`joined-${member.inboxId}`}
           inboxId={member.inboxId as IXmtpInboxId}
+          invitedByInboxId={content.initiatedByInboxId as IXmtpInboxId}
         />
       ))}
 
@@ -94,12 +95,18 @@ function ChatGroupMemberLeft({ inboxId }: IChatGroupMemberLeftProps) {
 
 type IChatGroupMemberJoinedProps = {
   inboxId: IXmtpInboxId
+  invitedByInboxId: IXmtpInboxId
 }
 
-function ChatGroupMemberJoined({ inboxId }: IChatGroupMemberJoinedProps) {
+function ChatGroupMemberJoined({ inboxId, invitedByInboxId }: IChatGroupMemberJoinedProps) {
   const { themed, theme } = useAppTheme()
   const { displayName, avatarUrl } = usePreferredDisplayInfo({
     inboxId,
+    caller: "ChatGroupMemberJoined",
+  })
+
+  const { displayName: invitedByDisplayName, avatarUrl: invitedByAvatarUrl } = usePreferredDisplayInfo({
+    inboxId: invitedByInboxId,
     caller: "ChatGroupMemberJoined",
   })
 
@@ -116,7 +123,23 @@ function ChatGroupMemberJoined({ inboxId }: IChatGroupMemberJoinedProps) {
         <Avatar sizeNumber={theme.avatarSize.xs} uri={avatarUrl} name={displayName ?? ""} />
         <ChatGroupUpdateText weight="bold">{displayName ?? ""}</ChatGroupUpdateText>
       </Pressable>
-      <ChatGroupUpdateText>joined</ChatGroupUpdateText>
+      <ChatGroupUpdateText>was invited</ChatGroupUpdateText>
+
+      {/* Show inviter if their displayName is available */}
+      {invitedByDisplayName && (
+        <Pressable
+          onPress={() => {
+            navigate("Profile", {
+              inboxId: invitedByInboxId,
+            })
+          }}
+        style={themed($pressableContent)}
+      >
+          <ChatGroupUpdateText>by</ChatGroupUpdateText>
+          <Avatar sizeNumber={theme.avatarSize.xs} uri={invitedByAvatarUrl} name={invitedByDisplayName ?? ""} />
+          <ChatGroupUpdateText weight="bold">{invitedByDisplayName ?? ""}</ChatGroupUpdateText>
+        </Pressable>
+      )}
     </HStack>
   )
 }


### PR DESCRIPTION
### Display inviter profile information in group chat member invitation messages to show who invited new members
Updates the `ChatGroupMemberJoined` component in [conversation-message-group-update.tsx](https://github.com/ephemeraHQ/convos-app/pull/50/files#diff-66ab4676af70597d6fd78cb834bf996107b41ff73d448b4ee6ea6459f8b3093a) to display inviter information when new members join a group chat. The component now includes the inviter's avatar, display name, and a clickable link to their profile, changing the message text from "joined" to "was invited by [inviter name]".

#### 📍Where to Start
Start with the `ChatGroupMemberJoined` component in [conversation-message-group-update.tsx](https://github.com/ephemeraHQ/convos-app/pull/50/files#diff-66ab4676af70597d6fd78cb834bf996107b41ff73d448b4ee6ea6459f8b3093a) where the new inviter display logic is implemented.

----

_[Macroscope](https://app.macroscope.com) summarized 1efcd97._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Group join messages now display who invited the new member, including the inviter's avatar and display name.
  - The inviter's information is clickable and navigates to their profile, if available.

- **Style**
  - Updated the group join message text from "joined" to "was invited" for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->