### PR TITLE
Update to xmtp rn sdk 4.2.0-rc3

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@turnkey/viem": "^0.9.0",
     "@walletconnect/react-native-compat": "^2.19.0",
     "@xmtp/content-type-primitives": "^2.0.0",
-    "@xmtp/react-native-sdk": "4.2.0-rc2",
+    "@xmtp/react-native-sdk": "4.2.0-rc3",
     "@xstate/react": "^5.0.0",
     "@yornaath/batshit": "^0.10.1",
     "alchemy-sdk": "^3.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9007,9 +9007,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/react-native-sdk@npm:4.2.0-rc2":
-  version: 4.2.0-rc2
-  resolution: "@xmtp/react-native-sdk@npm:4.2.0-rc2"
+"@xmtp/react-native-sdk@npm:4.2.0-rc3":
+  version: 4.2.0-rc3
+  resolution: "@xmtp/react-native-sdk@npm:4.2.0-rc3"
   dependencies:
     "@changesets/changelog-git": "npm:^0.2.0"
     "@changesets/cli": "npm:^2.27.10"
@@ -9023,7 +9023,7 @@ __metadata:
     expo: "*"
     react: "*"
     react-native: "*"
-  checksum: 10c0/751a3b09a2f148c3f99cf5baca8ac8a4f74d2966bae0e6497be903d29ef7b58e3d156471754cc504aef021180ccb69fe3ab0f333567de099cb2590d6d5732b5d
+  checksum: 10c0/a9d146bde53ce8d3af805d005836ef235c2da53aae72b280f2352343c45adf590a203b93443d49ee52604f9658916532b902c30d216da7b436fa3934b1daf163
   languageName: node
   linkType: hard
 
@@ -11031,7 +11031,7 @@ __metadata:
     "@walletconnect/react-native-compat": "npm:^2.19.0"
     "@welldone-software/why-did-you-render": "npm:^8.0.3"
     "@xmtp/content-type-primitives": "npm:^2.0.0"
-    "@xmtp/react-native-sdk": "npm:4.2.0-rc2"
+    "@xmtp/react-native-sdk": "npm:4.2.0-rc3"
     "@xstate/react": "npm:^5.0.0"
     "@yornaath/batshit": "npm:^0.10.1"
     alchemy-sdk: "npm:^3.4.4"


### PR DESCRIPTION
### Update XMTP React Native SDK dependency to version 4.2.0-rc3
Updates the `@xmtp/react-native-sdk` package version in [package.json](https://github.com/ephemeraHQ/convos-app/pull/52/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) from `4.2.0-rc2` to `4.2.0-rc3`, with corresponding changes reflected in [yarn.lock](https://github.com/ephemeraHQ/convos-app/pull/52/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de).

#### 📍Where to Start
Start with the dependency version update in [package.json](https://github.com/ephemeraHQ/convos-app/pull/52/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to verify the version change from `4.2.0-rc2` to `4.2.0-rc3`.

----

_[Macroscope](https://app.macroscope.com) summarized 94eabf6._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version of the @xmtp/react-native-sdk dependency to 4.2.0-rc3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->