### PR TITLE
fix: inline reply tap handler touch behavior

### DIFF
--- a/features/conversation/conversation-chat/conversation-message/conversation-message-reply.tsx
+++ b/features/conversation/conversation-chat/conversation-message/conversation-message-reply.tsx
@@ -175,13 +175,14 @@ const MessageReplyReference = memo(function MessageReplyReference(props: {
   })
 
   const tapGesture = Gesture.Tap()
-    .onBegin(() => {
+    .onEnd(() => {
       Haptics.softImpactAsync()
       conversationStore.setState({
         highlightedXmtpMessageId: referenceMessageId,
         scrollToXmtpMessageId: referenceMessageId,
       })
     })
+    .maxDistance(10)
     .runOnJS(true)
 
   return (


### PR DESCRIPTION
### Update MessageReplyReference tap gesture handler to trigger on touch end with 10-unit maximum distance constraint
The gesture handler in the `MessageReplyReference` component within [conversation-message-reply.tsx](https://github.com/ephemeraHQ/convos-app/pull/60/files#diff-156bd99fb4d3501a24322e9eff4e3720e76b34ab2030eff2bd1ba74f82c98cef) has been modified to:

* Change tap gesture trigger from `.onBegin()` to `.onEnd()`
* Add `.maxDistance(10)` constraint to the tap gesture recognition

#### 📍Where to Start
Begin reviewing the tap gesture handler changes in the `MessageReplyReference` component within [conversation-message-reply.tsx](https://github.com/ephemeraHQ/convos-app/pull/60/files#diff-156bd99fb4d3501a24322e9eff4e3720e76b34ab2030eff2bd1ba74f82c98cef)

----

_[Macroscope](https://app.macroscope.com) summarized acf57c3._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved tap gesture handling on message replies so that actions now occur only after a tap is completed with minimal finger movement, providing a more accurate and responsive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->