### PR TITLE
feat: implement a tap to retry to load attachment

### DIFF
--- a/features/conversation/conversation-chat/conversation-attachment/conversation-attachment-remote-image.tsx
+++ b/features/conversation/conversation-chat/conversation-attachment/conversation-attachment-remote-image.tsx
@@ -14,6 +14,8 @@ import {
   ConversationMessageAttachmentContainer,
   IConversationMessageAttachmentContainerProps,
 } from "./conversation-message-attachment-container"
+import { VStack } from "@/design-system/VStack"
+import { Icon } from "@/design-system/Icon/Icon"
 
 type IConversationAttachmentRemoteImageProps = {
   imageUrl: Nullable<string>
@@ -28,8 +30,15 @@ type IConversationAttachmentRemoteImageProps = {
 export const ConversationAttachmentRemoteImage = memo(function ConversationAttachmentRemoteImage(
   props: IConversationAttachmentRemoteImageProps,
 ) {
-  const { imageUrl, isLoading, error, fitAspectRatio, containerProps, imageProps, imageSize } =
-    props
+  const { 
+    imageUrl, 
+    isLoading, 
+    error, 
+    fitAspectRatio, 
+    containerProps, 
+    imageProps, 
+    imageSize
+  } = props
 
   const { borderRadius } = useConversationAttachmentStyles()
 
@@ -44,7 +53,10 @@ export const ConversationAttachmentRemoteImage = memo(function ConversationAttac
   if (error || !imageUrl) {
     return (
       <ConversationMessageAttachmentContainer {...containerProps}>
-        <Text>{translate("attachment_message_error_download")}</Text>
+        <VStack style={{ alignItems: "center", justifyContent: "center", height: "100%" }}>
+          <Text>Couldn't load attachment</Text>
+          <Text>Tap to retry</Text>
+        </VStack>
       </ConversationMessageAttachmentContainer>
     )
   }
@@ -95,7 +107,7 @@ export const ConversationAttachmentRemoteImageSmart = memo(
     const {
       data: attachment,
       error: attachmentError,
-      isLoading: attachmentLoading,
+      isLoading: attachmentLoading
     } = useRemoteAttachmentQuery({
       xmtpMessageId,
       url,

--- a/features/conversation/conversation-chat/conversation-attachment/conversation-message-remote-attachment.tsx
+++ b/features/conversation/conversation-chat/conversation-attachment/conversation-message-remote-attachment.tsx
@@ -30,6 +30,7 @@ export const ConversationMessageRemoteAttachment = memo(
       data: attachment,
       isLoading: attachmentLoading,
       error: attachmentError,
+      refetch: refetchAttachment,
     } = useRemoteAttachmentQuery({
       xmtpMessageId: message.xmtpId,
       url,
@@ -37,14 +38,17 @@ export const ConversationMessageRemoteAttachment = memo(
     })
 
     const handleTap = useCallback(() => {
-      if (attachment?.mediaURL) {
-        useGlobalMediaViewerStore.getState().actions.openGlobalMediaViewer({
-          uri: attachment?.mediaURL,
-          sender: displayName,
-          timestamp: message.sentMs,
-        })
+      if (attachmentError || !attachment?.mediaURL) {
+        refetchAttachment()
+        return
       }
-    }, [attachment?.mediaURL, displayName, message.sentMs])
+
+      useGlobalMediaViewerStore.getState().actions.openGlobalMediaViewer({
+        uri: attachment.mediaURL,
+        sender: displayName,
+        timestamp: message.sentMs,
+      })
+    }, [attachment?.mediaURL, attachmentError, displayName, message.sentMs, refetchAttachment])
 
     return (
       <VStack

--- a/i18n/translations/en.ts
+++ b/i18n/translations/en.ts
@@ -303,7 +303,6 @@ export const en = {
     "Your group chats will be encrypted and saved on your device until you delete Converse. Your DMs will be backed up by the XMTP network.",
   your_profile_page: "Your profile page",
   copy_wallet_address: "Copy wallet address",
-  attachment_message_error_download: "Couldn't download attachment",
 
   // Context Menu
   reply: "Reply",

--- a/i18n/translations/fr.ts
+++ b/i18n/translations/fr.ts
@@ -323,7 +323,6 @@ export const fr = {
     "Vos discussions de groupe seront chiffrées et sauvegardées sur votre appareil jusqu'à ce que vous supprimiez Convos. Vos messages privés seront sauvegardés par le réseau XMTP.",
   your_profile_page: "Votre page de profil",
   copy_wallet_address: "Copier l'adresse du portefeuille",
-  attachment_message_error_download: "Impossible de télécharger la pièce jointe",
 
   // Context Menu
   reply: "Répondre",


### PR DESCRIPTION
### Add tap-to-retry functionality for failed attachment downloads in conversation image attachments
* Updates the `ConversationMessageRemoteAttachment` component in [conversation-message-remote-attachment.tsx](https://github.com/ephemeraHQ/convos-app/pull/62/files#diff-88b29ba9de4cb52319ae072b9fb3c39e1be7bd8decf1ee748918ef53d42331a0) to handle retrying failed attachment downloads using the `refetchAttachment` function
* Modifies error display in [conversation-attachment-remote-image.tsx](https://github.com/ephemeraHQ/convos-app/pull/62/files#diff-42afc1f5150bd184bef4e42c51bfa66cd0585b37cbad41305af8e375a377fde4) to show a vertically stacked layout with retry instructions
* Removes hardcoded error messages from translation files [en.ts](https://github.com/ephemeraHQ/convos-app/pull/62/files#diff-6b04482a523e9eeb55ca5808e1e4e4afc19b11b5b2104f20ec8a51c721e2129c) and [fr.ts](https://github.com/ephemeraHQ/convos-app/pull/62/files#diff-faa5a1e1698e09dfa34dc4ac2e2acc6eb2d72d6129183b5f9543a3fa52014ea4)

#### 📍Where to Start
Start with the `handleTap` function in [conversation-message-remote-attachment.tsx](https://github.com/ephemeraHQ/convos-app/pull/62/files#diff-88b29ba9de4cb52319ae072b9fb3c39e1be7bd8decf1ee748918ef53d42331a0) which contains the core retry logic.

----

_[Macroscope](https://app.macroscope.com) summarized 8eb3f0f._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the error display for remote image attachments with clearer, vertically stacked messages and a prompt to retry.
  - Fixed tap behavior on attachment errors to allow retrying the download instead of failing silently.

- **Documentation**
  - Updated translations by removing unused error message keys in English and French.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->