### PR TITLE
Fix missing contentTopic in notification

### DIFF
--- a/plugins/notification-service-extension/plugin/swift/NotificationService.swift
+++ b/plugins/notification-service-extension/plugin/swift/NotificationService.swift
@@ -118,7 +118,9 @@ final class NotificationService: UNNotificationServiceExtension {
                 }
 
               let notificationFactory = PushNotificationContentFactory(client: client)
-              guard let notification = try await notificationFactory.notification(from: decodedMessage, in: conversation) else {
+              guard let notification = try await notificationFactory.notification(from: request.content,
+                                                                                  with: decodedMessage,
+                                                                                  in: conversation) else {
                 log.error("Failed getting notification from decoded message")
                 contentHandler?(currentBestAttempt)
                 return

--- a/plugins/notification-service-extension/plugin/swift/PushNotificationContentFactory.swift
+++ b/plugins/notification-service-extension/plugin/swift/PushNotificationContentFactory.swift
@@ -88,9 +88,10 @@ class PushNotificationContentFactory {
         return try await client.conversations.findMessage(messageId: reference)
     }
 
-    func notification(from decodedMessage: DecodedMessage,
-                      in conversation: Conversation) async throws -> UNNotificationContent? {
-        let mutableNotification = UNMutableNotificationContent()
+  func notification(from originalNotification: UNNotificationContent,
+                    with decodedMessage: DecodedMessage,
+                    in conversation: Conversation) async throws -> UNNotificationContent? {
+        let mutableNotification = originalNotification.mutableCopy() as? UNMutableNotificationContent ?? UNMutableNotificationContent()
         let decoder = XMTPContentDecoder()
         let content = try decoder.decode(message: decodedMessage)
 


### PR DESCRIPTION
### Pass original notification content to preserve contentTopic in `PushNotificationContentFactory.notification` method
The notification handling flow has been modified to preserve original notification content:

* The `NotificationService` class now passes the original `request.content` to the notification factory in [NotificationService.swift](https://github.com/ephemeraHQ/convos-app/pull/64/files#diff-cff5881e37a39f89aac7f80f7c666ae5ce584c0694908c894eabd8a1847d936e)
* The `PushNotificationContentFactory.notification` method creates a mutable copy of the original notification instead of an empty one in [PushNotificationContentFactory.swift](https://github.com/ephemeraHQ/convos-app/pull/64/files#diff-a7a7cc7d646beb4a5390c3ad988a61a3c86f123409712268e307c7e41e574463)

#### 📍Where to Start
Start with the `notification` method in [PushNotificationContentFactory.swift](https://github.com/ephemeraHQ/convos-app/pull/64/files#diff-a7a7cc7d646beb4a5390c3ad988a61a3c86f123409712268e307c7e41e574463) which now accepts and uses the original notification content parameter.

----

_[Macroscope](https://app.macroscope.com) summarized 3a935bf._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved notification handling by utilizing additional context from the original notification content, decoded message, and conversation when generating notifications.

- **Refactor**
  - Updated notification generation logic to accept more contextual information for enhanced customization of notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->