### PR TITLE
fix file log modal

### DIFF
--- a/components/debug-menu.tsx
+++ b/components/debug-menu.tsx
@@ -35,12 +35,18 @@ import { reactQueryPersitingStorage } from "@/utils/react-query/react-query-pers
 import { reactQueryClient } from "@/utils/react-query/react-query.client"
 import { shareContent } from "@/utils/share"
 import { showActionSheet } from "./action-sheet"
+import { useXmtpLogFilesModalActions } from "./xmtp-log-files-modal"
 
 export const DebugMenuWrapper = memo(function DebugWrapper(props: { children: React.ReactNode }) {
   const { children } = props
+  const { setVisible } = useXmtpLogFilesModalActions()
+
 
   const showDebugMenu = useShowDebugMenu({
-    setLogFilesModalVisible: () => {},
+    setLogFilesModalVisible: (visible: boolean) => {
+      console.log("setLogFilesModalVisible", visible)
+      setVisible(visible)
+    },
   })
 
   const longPressGesture = Gesture.LongPress()

--- a/components/xmtp-log-files-modal.tsx
+++ b/components/xmtp-log-files-modal.tsx
@@ -28,6 +28,9 @@ const initialState: IXmtpLogFilesModalState = {
   visible: false,
 }
 
+export const useXmtpLogFilesModalActions = () => 
+  useXmtpLogFilesModalStore((state) => state.actions)
+
 const useXmtpLogFilesModalStore = create<IXmtpLogFilesModalStore>((set, get) => ({
   ...initialState,
   actions: {


### PR DESCRIPTION
### Implement XMTP log files modal visibility control in debug menu
* Adds new `useXmtpLogFilesModalActions` hook in [xmtp-log-files-modal.tsx](https://github.com/ephemeraHQ/convos-app/pull/69/files#diff-961876f72e13b4dc9707673aa167453e46b5b7f2a49b410c09299f79351df967) to expose modal actions
* Implements `setLogFilesModalVisible` function in [debug-menu.tsx](https://github.com/ephemeraHQ/convos-app/pull/69/files#diff-3e1bd98562020bef369721c02945be19adef1415651924570ebc5c05ea4baa95) using the new hook

#### 📍Where to Start
Start with the new `useXmtpLogFilesModalActions` hook in [xmtp-log-files-modal.tsx](https://github.com/ephemeraHQ/convos-app/pull/69/files#diff-961876f72e13b4dc9707673aa167453e46b5b7f2a49b410c09299f79351df967), then follow the implementation in [debug-menu.tsx](https://github.com/ephemeraHQ/convos-app/pull/69/files#diff-3e1bd98562020bef369721c02945be19adef1415651924570ebc5c05ea4baa95) to see how it's used.

----

_[Macroscope](https://app.macroscope.com) summarized a0193d7._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The "View Libxmtp File Logs" option in the debug menu now opens and closes the XMTP log files modal, allowing users to view log files directly from the debug menu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->