### PR TITLE
Update `expo-image` and clear image cache on log out

### DIFF
--- a/features/authentication/use-logout.ts
+++ b/features/authentication/use-logout.ts
@@ -15,6 +15,7 @@ import { GenericError } from "@/utils/error"
 import { customPromiseAllSettled } from "@/utils/promise-all-settled"
 import { clearReacyQueryQueriesAndCache } from "@/utils/react-query/react-query.utils"
 import { authLogger } from "../../utils/logger/logger"
+import { Image } from "expo-image"
 
 export const useLogout = () => {
   const { clearAllSessions: clearTurnkeySessions } = useTurnkey()
@@ -138,6 +139,13 @@ export const useLogout = () => {
           additionalMessage: "Error logging out",
         })
       } finally {
+        // Clear expo-image cache after logout for privacy and to avoid stale images
+        try {
+          await Image.clearDiskCache()
+          await Image.clearMemoryCache()
+        } catch (e) {
+          captureError(new GenericError({ error: e, additionalMessage: "Error clearing image cache after logout" }))
+        }
         useAppStore.getState().actions.setIsLoggingOut(false)
       }
     },

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "expo-document-picker": "~13.0.1",
     "expo-file-system": "~18.0.4",
     "expo-haptics": "~14.0.0",
-    "expo-image": "~2.0.2",
+    "expo-image": "^2.1.7",
     "expo-image-manipulator": "~13.0.5",
     "expo-image-picker": "~16.0.3",
     "expo-linear-gradient": "~14.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11093,7 +11093,7 @@ __metadata:
     expo-document-picker: "npm:~13.0.1"
     expo-file-system: "npm:~18.0.4"
     expo-haptics: "npm:~14.0.0"
-    expo-image: "npm:~2.0.2"
+    expo-image: "npm:^2.1.7"
     expo-image-manipulator: "npm:~13.0.5"
     expo-image-picker: "npm:~16.0.3"
     expo-linear-gradient: "npm:~14.0.1"
@@ -13191,9 +13191,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-image@npm:~2.0.2":
-  version: 2.0.7
-  resolution: "expo-image@npm:2.0.7"
+"expo-image@npm:^2.1.7":
+  version: 2.1.7
+  resolution: "expo-image@npm:2.1.7"
   peerDependencies:
     expo: "*"
     react: "*"
@@ -13202,7 +13202,7 @@ __metadata:
   peerDependenciesMeta:
     react-native-web:
       optional: true
-  checksum: 10c0/b817b733e1bbf2bc04a227f7e8b95603a50824f9c9eaa9ea5ebc32e9232514283a81c37e7fc3fd313e4f9f7a362ef40ade3c74d3bbe905e5784647c104411ede
+  checksum: 10c0/19f1025b031b3ec344cdf7939334063c3a0487bd604bf7c8c7620e9fd6ddde9192749a759e4e2ba59e3a75ffcbfa897ced27faa6af7240cdc855c1681c097945
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We might want to update expo-image to 2.1.8 when it is available, to help with the image downsampling: https://github.com/expo/expo/pull/36776