### PR TITLE
feat(groups): improve group members list sorting

### DIFF
--- a/features/groups/components/group-details-members-list.component.tsx
+++ b/features/groups/components/group-details-members-list.component.tsx
@@ -1,17 +1,22 @@
-import { memo, useCallback, useMemo } from "react"
+import { memo, useCallback, useEffect, useMemo, useState } from "react"
+import { ActivityIndicator } from "react-native"
 import { VStack } from "@/design-system/VStack"
 import { Pressable } from "@/design-system/Pressable"
 import { ListItemEndRightChevron } from "@/design-system/list-item"
+import { Center } from "@/design-system/Center"
 import { useSafeCurrentSender } from "@/features/authentication/multi-inbox.store"
 import { GroupMemberDetailsBottomSheet } from "@/features/groups/components/group-member-details/group-member-details.bottom-sheet"
 import { useGroupMembers } from "@/features/groups/hooks/use-group-members"
 import { GroupDetailsListItem } from "@/features/groups/ui/group-details.ui"
 import { sortGroupMembers } from "@/features/groups/utils/sort-group-members"
-import { IXmtpConversationId } from "@/features/xmtp/xmtp.types"
+import { IXmtpConversationId, IXmtpInboxId } from "@/features/xmtp/xmtp.types"
 import { useRouter } from "@/navigation/use-navigation"
 import { useAppTheme } from "@/theme/use-app-theme"
 import { MemberListItem } from "./group-details-members-list-item.component"
 import { GroupDetailsMembersListHeader } from "./group-details-members-list-header.component"
+import { ensureProfileQueryData } from "@/features/profiles/profiles.query"
+import { captureError } from "@/utils/capture-error"
+import { GenericError } from "@/utils/error"
 
 export const GroupDetailsMembersList = memo(function GroupDetailsMembersList(props: {
   xmtpConversationId: IXmtpConversationId
@@ -20,17 +25,64 @@ export const GroupDetailsMembersList = memo(function GroupDetailsMembersList(pro
   const router = useRouter()
   const { theme } = useAppTheme()
   const currentSenderInboxId = useSafeCurrentSender().inboxId
+  const [sortedMemberIds, setSortedMemberIds] = useState<IXmtpInboxId[]>([])
+  const [isLoadingProfiles, setIsLoadingProfiles] = useState(false)
 
-  const { members } = useGroupMembers({
+  const { members, isLoading: isLoadingMembers } = useGroupMembers({
     caller: "GroupDetailsScreen",
     clientInboxId: currentSenderInboxId,
     xmtpConversationId,
   })
 
-  const sortedMembers = useMemo(() => {
-    return sortGroupMembers(Object.values(members?.byId || {}).filter(Boolean))
-  }, [members])
+  // Load profiles and sort members
+  useEffect(() => {
+    if (!members?.ids?.length) return
 
+    setIsLoadingProfiles(true)
+    
+    // Get member inbox IDs
+    const memberInboxIds = members.ids.map(id => members.byId[id].inboxId)
+    
+    // Load all profiles
+    Promise.all(
+      memberInboxIds.map(inboxId => 
+        ensureProfileQueryData({ 
+          xmtpId: inboxId, 
+          caller: "GroupDetailsMembersList" 
+        })
+      )
+    )
+    .then(profiles => {
+      // Create member-profile pairs for enhanced sorting
+      const memberProfilePairs = Object.values(members.byId).map((member, idx) => {
+        // Find the profile by matching member's inboxId
+        const profileIndex = memberInboxIds.findIndex(id => id === member.inboxId)
+        const profile = profileIndex !== -1 ? profiles[profileIndex] : null
+        return { 
+          ...member,
+          profile
+        }
+      })
+      
+      // Use the enhanced sorting with profiles
+      const sorted = sortGroupMembers(memberProfilePairs)
+      
+      // Extract just the inbox IDs
+      setSortedMemberIds(sorted.map(member => member.inboxId))
+      setIsLoadingProfiles(false)
+    })
+    .catch(error => {
+      captureError(new GenericError({
+        error,
+        additionalMessage: "Error loading profiles for group members list"
+      }))
+      // Fall back to basic sorting without profiles
+      const sortedMembers = sortGroupMembers(Object.values(members.byId))
+      setSortedMemberIds(sortedMembers.map(member => member.inboxId))
+      setIsLoadingProfiles(false)
+    })
+  }, [members?.ids, members?.byId])
+  
   const handleAddMembersPress = useCallback(() => {
     router.push("AddGroupMembers", { xmtpConversationId })
   }, [xmtpConversationId, router])
@@ -39,9 +91,30 @@ export const GroupDetailsMembersList = memo(function GroupDetailsMembersList(pro
     router.push("GroupMembersList", { xmtpConversationId })
   }, [xmtpConversationId, router])
 
-  // For demo purposes, we'll show a limited number of members
-  const visibleMembers = sortedMembers.slice(0, 6)
-  const hasMoreMembers = sortedMembers.length > visibleMembers.length
+  // Show a limited number of members
+  const visibleMemberIds = sortedMemberIds.slice(0, 6)
+  const hasMoreMembers = sortedMemberIds.length > visibleMemberIds.length
+
+  // Show loading state
+  if (isLoadingMembers || isLoadingProfiles) {
+    return (
+      <VStack
+        style={{
+          backgroundColor: theme.colors.background.surface,
+          paddingVertical: theme.spacing.md,
+        }}
+      >
+        <Center style={{ height: 100 }}>
+          <ActivityIndicator size="small" />
+        </Center>
+      </VStack>
+    )
+  }
+
+  // If no members, show nothing
+  if (!members?.ids?.length || sortedMemberIds.length === 0) {
+    return null
+  }
 
   return (
     <VStack
@@ -53,20 +126,20 @@ export const GroupDetailsMembersList = memo(function GroupDetailsMembersList(pro
       {/* Members Header */}
       <GroupDetailsMembersListHeader
         xmtpConversationId={xmtpConversationId}
-        memberCount={sortedMembers.length}
+        memberCount={sortedMemberIds.length}
         onAddMember={handleAddMembersPress}
       />
 
       {/* Members List */}
       <VStack>
-        {visibleMembers.map((member) => {
-          return <MemberListItem key={member.inboxId} memberInboxId={member.inboxId} />
+        {visibleMemberIds.map((inboxId) => {
+          return <MemberListItem key={inboxId} memberInboxId={inboxId} />
         })}
 
         {hasMoreMembers && (
           <Pressable onPress={handleSeeAllPress} hitSlop={theme.spacing.sm}>
             <GroupDetailsListItem
-              title={`See all ${sortedMembers.length}`}
+              title={`See all ${sortedMemberIds.length}`}
               end={<ListItemEndRightChevron />}
             />
           </Pressable>

--- a/features/groups/components/group-details-members-list.component.tsx
+++ b/features/groups/components/group-details-members-list.component.tsx
@@ -12,7 +12,8 @@ import { useRouter } from "@/navigation/use-navigation"
 import { useAppTheme } from "@/theme/use-app-theme"
 import { MemberListItem } from "./group-details-members-list-item.component"
 import { GroupDetailsMembersListHeader } from "./group-details-members-list-header.component"
-import { useGroupMembersWithSorting } from "@/features/groups/queries/group-members-sorted.query"
+import { useSortedGroupMembers } from "@/features/groups/queries/group-members-sorted.query"
+import { Loader } from "@/design-system/loader"
 
 export const GroupDetailsMembersList = memo(function GroupDetailsMembersList(props: {
   xmtpConversationId: IXmtpConversationId
@@ -22,7 +23,7 @@ export const GroupDetailsMembersList = memo(function GroupDetailsMembersList(pro
   const { theme } = useAppTheme()
   const currentSenderInboxId = useSafeCurrentSender().inboxId
   
-  const { members, sortedMemberIds, isLoading } = useGroupMembersWithSorting({
+  const { data: sortedMemberIds = [], isLoading } = useSortedGroupMembers({
     caller: "GroupDetailsScreen",
     clientInboxId: currentSenderInboxId,
     xmtpConversationId,
@@ -50,14 +51,14 @@ export const GroupDetailsMembersList = memo(function GroupDetailsMembersList(pro
         }}
       >
         <Center style={{ height: 100 }}>
-          <ActivityIndicator size="small" />
+          <Loader />
         </Center>
       </VStack>
     )
   }
 
   // If no members, show nothing
-  if (!members?.ids?.length || sortedMemberIds.length === 0) {
+  if (sortedMemberIds.length === 0) {
     return null
   }
 

--- a/features/groups/queries/group-members-sorted.query.ts
+++ b/features/groups/queries/group-members-sorted.query.ts
@@ -1,0 +1,115 @@
+import { queryOptions, useQuery } from "@tanstack/react-query"
+import { ensureProfileQueryData } from "@/features/profiles/profiles.query"
+import { useGroupMembers } from "@/features/groups/hooks/use-group-members"
+import { sortGroupMembers, IGroupMemberWithProfile } from "@/features/groups/utils/sort-group-members"
+import { IXmtpConversationId, IXmtpInboxId } from "@/features/xmtp/xmtp.types"
+import { reactQueryClient } from "@/utils/react-query/react-query.client"
+import { getReactQueryKey } from "@/utils/react-query/react-query.utils"
+import { captureError } from "@/utils/capture-error"
+import { GenericError } from "@/utils/error"
+import { getGroupQueryOptions } from "./group.query"
+
+type IArgs = {
+  clientInboxId: IXmtpInboxId
+  xmtpConversationId: IXmtpConversationId
+}
+
+type IArgsWithCaller = IArgs & {
+  caller: string
+}
+
+export function getSortedGroupMembersQueryOptions(args: IArgsWithCaller) {
+  const { clientInboxId, xmtpConversationId, caller } = args
+
+  return queryOptions({
+    queryKey: getReactQueryKey({
+      baseStr: "sortedGroupMembers",
+      clientInboxId,
+      xmtpConversationId,
+    }),
+    queryFn: async () => {
+      try {
+        const members = await reactQueryClient.fetchQuery({
+          queryKey: getReactQueryKey({
+            baseStr: "group",
+            clientInboxId, 
+            xmtpConversationId,
+            caller: `getSortedGroupMembersQuery:${caller}`,
+          }),
+          queryFn: async () => {
+            const group = await reactQueryClient.fetchQuery(
+              getGroupQueryOptions({
+                clientInboxId,
+                xmtpConversationId,
+                caller: `getSortedGroupMembersQuery:${caller}`,
+              })
+            )
+            return group?.members
+          },
+        })
+
+        if (!members?.ids?.length) {
+          return []
+        }
+
+        // Get member inbox IDs
+        const memberInboxIds = members.ids.map(id => members.byId[id].inboxId)
+        
+        // Load all profiles
+        const profiles = await Promise.all(
+          memberInboxIds.map(inboxId => 
+            ensureProfileQueryData({ 
+              xmtpId: inboxId, 
+              caller: `getSortedGroupMembersQuery:${caller}` 
+            })
+          )
+        )
+        
+        // Create member-profile pairs for enhanced sorting
+        const memberProfilePairs = Object.values(members.byId).map(member => {
+          // Find the profile by matching member's inboxId
+          const profileIndex = memberInboxIds.findIndex(id => id === member.inboxId)
+          const profile = profileIndex !== -1 ? profiles[profileIndex] : null
+          return { 
+            ...member,
+            profile
+          } as IGroupMemberWithProfile
+        })
+        
+        // Use the enhanced sorting with profiles
+        const sorted = sortGroupMembers(memberProfilePairs)
+        
+        // Return sorted inbox IDs
+        return sorted.map(member => member.inboxId)
+
+      } catch (error) {
+        captureError(new GenericError({
+          error,
+          additionalMessage: "Error loading sorted group members",
+        }))
+        
+        // Return an empty array in case of error
+        return []
+      }
+    },
+  })
+}
+
+export function useSortedGroupMembers(args: IArgsWithCaller) {
+  return useQuery(getSortedGroupMembersQueryOptions(args))
+}
+
+export async function getSortedGroupMembersQueryData(args: IArgsWithCaller) {
+  return reactQueryClient.ensureQueryData(getSortedGroupMembersQueryOptions(args))
+}
+
+export function useGroupMembersWithSorting(args: IArgsWithCaller) {
+  const { data: sortedMemberIds, isLoading: isLoadingSorted } = useSortedGroupMembers(args)
+  const { members, isLoading: isLoadingMembers } = useGroupMembers(args)
+
+  return {
+    members,
+    sortedMemberIds: sortedMemberIds || [],
+    isLoading: isLoadingMembers || isLoadingSorted
+  }
+}

--- a/features/groups/queries/group-members-sorted.query.ts
+++ b/features/groups/queries/group-members-sorted.query.ts
@@ -65,14 +65,17 @@ export function getSortedGroupMembersQueryOptions(args: IArgsWithCaller) {
           )
         )
         
-        // Create member-profile pairs for enhanced sorting
+        // Create member-profile pairs with proper profiles
         const memberProfilePairs = Object.values(members.byId).map(member => {
           // Find the profile by matching member's inboxId
           const profileIndex = memberInboxIds.findIndex(id => id === member.inboxId)
+          // Ensure we have a proper profile object, even if data is missing
           const profile = profileIndex !== -1 ? profiles[profileIndex] : null
           return { 
             ...member,
-            profile
+            profile: {
+              name: profile?.name || ""
+            }
           } as IGroupMemberWithProfile
         })
         

--- a/features/groups/screens/group-members-list.screen.tsx
+++ b/features/groups/screens/group-members-list.screen.tsx
@@ -1,7 +1,6 @@
 import { NativeStackScreenProps } from "@react-navigation/native-stack"
 import { FlashList } from "@shopify/flash-list"
-import React, { memo, useCallback, useEffect } from "react"
-import { ActivityIndicator } from "react-native"
+import React, { memo, useCallback } from "react"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { Screen } from "@/components/screen/screen"
 import { Center } from "@/design-system/Center"
@@ -9,13 +8,12 @@ import { EmptyState } from "@/design-system/empty-state"
 import { useSafeCurrentSender } from "@/features/authentication/multi-inbox.store"
 import { MemberListItem } from "@/features/groups/components/group-details-members-list-item.component"
 import { GroupMemberDetailsBottomSheet } from "@/features/groups/components/group-member-details/group-member-details.bottom-sheet"
-import { useGroupMembersWithSorting } from "@/features/groups/queries/group-members-sorted.query"
-import { refetchGroupQuery } from "@/features/groups/queries/group.query"
+import { useSortedGroupMembers } from "@/features/groups/queries/group-members-sorted.query"
 import { NavigationParamList } from "@/navigation/navigation.types"
 import { useHeader } from "@/navigation/use-header"
 import { useRouteParams, useRouter } from "@/navigation/use-navigation"
 import { $globalStyles } from "@/theme/styles"
-import { captureError } from "@/utils/capture-error"
+import { Loader } from "@/design-system/loader"
 
 export const GroupMembersListScreen = memo(function GroupMembersListScreen(
   props: NativeStackScreenProps<NavigationParamList, "GroupMembersList">,
@@ -59,32 +57,22 @@ const List = memo(function List() {
   const currentSender = useSafeCurrentSender()
   const { xmtpConversationId } = useRouteParams<"GroupMembersList">()
   
-  const { members, sortedMemberIds, isLoading } = useGroupMembersWithSorting({
+  const { data: sortedMemberIds = [], isLoading } = useSortedGroupMembers({
     xmtpConversationId,
     clientInboxId: currentSender.inboxId,
     caller: "GroupMembersListScreen",
   })
 
-  // If members list is empty, trigger a reload
-  useEffect(() => {
-    if (!isLoading && (!members?.ids?.length || sortedMemberIds.length === 0)) {
-      refetchGroupQuery({
-        clientInboxId: currentSender.inboxId,
-        xmtpConversationId,
-        caller: "GroupMembersListScreen-EmptyListReload",
-      }).catch(captureError)
-    }
-  }, [isLoading, members?.ids?.length, sortedMemberIds.length, currentSender.inboxId, xmtpConversationId])
 
   if (isLoading) {
     return (
       <Center style={$globalStyles.flex1}>
-        <ActivityIndicator size="large" />
+        <Loader />
       </Center>
     )
   }
 
-  if (!members) {
+  if (sortedMemberIds.length === 0) {
     return (
       <EmptyState
         title="Members not found"

--- a/features/groups/screens/group-members-list.screen.tsx
+++ b/features/groups/screens/group-members-list.screen.tsx
@@ -1,6 +1,6 @@
 import { NativeStackScreenProps } from "@react-navigation/native-stack"
 import { FlashList } from "@shopify/flash-list"
-import { memo, useCallback } from "react"
+import React, { memo, useCallback } from "react"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { Screen } from "@/components/screen/screen"
 import { EmptyState } from "@/design-system/empty-state"

--- a/features/groups/utils/sort-group-members.ts
+++ b/features/groups/utils/sort-group-members.ts
@@ -3,108 +3,31 @@ import {
   getGroupMemberIsAdmin,
   getGroupMemberIsSuperAdmin,
 } from "@/features/groups/utils/group-admin.utils"
-import { getPreferredDisplayInfo } from "@/features/preferred-display-info/use-preferred-display-info"
 
-// Type that includes optional profile information
 export type IGroupMemberWithProfile = IGroupMember & {
-  profile?: {
+  profile: {
     name?: string
-    avatar?: string
-  } | null
-}
-
-export function sortGroupMembers(members: IGroupMember[] | IGroupMemberWithProfile[]) {
-  // First sort by admin status
-  const sortedByAdmin = [...members].sort((a, b) => {
-    // Create priority based on admin status
-    const getPriority = (member: IGroupMember): number => {
-      if (getGroupMemberIsSuperAdmin({ member })) return 2
-      if (getGroupMemberIsAdmin({ member })) return 1
-      return 0
-    }
-
-    const priorityA = getPriority(a)
-    const priorityB = getPriority(b)
-
-    // Sort by priority (higher first)
-    return priorityB - priorityA
-  })
-
-  // Check if we have profile information in the members
-  const hasProfiles = sortedByAdmin.some(m => 'profile' in m && m.profile)
-
-  if (hasProfiles) {
-    // If members have profiles, use those directly
-    return enhanceSortWithProfiles(sortedByAdmin as IGroupMemberWithProfile[])
-  } else {
-    // Otherwise, get profile info and then sort
-    const withProfiles = getProfilesAndEnhanceSort(sortedByAdmin)
-    return withProfiles
   }
 }
 
-// Sort with profile information that's already included in the members
-function enhanceSortWithProfiles(members: IGroupMemberWithProfile[]) {
-  return members.sort((a, b) => {
-    // First preserve admin sort order
-    if (a.permission === "super_admin" && b.permission !== "super_admin") return -1
-    if (a.permission !== "super_admin" && b.permission === "super_admin") return 1
-    if (a.permission === "admin" && b.permission !== "admin") return -1
-    if (a.permission !== "admin" && b.permission === "admin") return 1
+export function sortGroupMembers(members: IGroupMemberWithProfile[]) {
+  return [...members].sort((a, b) => {
+    // First sort by admin status
+    if (getGroupMemberIsSuperAdmin({ member: a }) && !getGroupMemberIsSuperAdmin({ member: b })) return -1
+    if (!getGroupMemberIsSuperAdmin({ member: a }) && getGroupMemberIsSuperAdmin({ member: b })) return 1
+    if (getGroupMemberIsAdmin({ member: a }) && !getGroupMemberIsAdmin({ member: b })) return -1
+    if (!getGroupMemberIsAdmin({ member: a }) && getGroupMemberIsAdmin({ member: b })) return 1
     
     // Then check for names
-    const hasNameA = !!(a.profile?.name && !a.profile.name.startsWith("0x"))
-    const hasNameB = !!(b.profile?.name && !b.profile.name.startsWith("0x"))
+    const hasNameA = !!(a.profile.name && !a.profile.name.startsWith("0x"))
+    const hasNameB = !!(b.profile.name && !b.profile.name.startsWith("0x"))
     
     if (hasNameA && !hasNameB) return -1
     if (!hasNameA && hasNameB) return 1
     
     // If both have names, sort alphabetically
     if (hasNameA && hasNameB) {
-      return a.profile!.name!.localeCompare(b.profile!.name!)
-    }
-    
-    // Otherwise keep original order
-    return 0
-  })
-}
-
-// Get profile information and then enhance the sort
-function getProfilesAndEnhanceSort(members: IGroupMember[]) {
-  // Pre-compute all display info
-  const memberDisplayInfo = new Map<string, { displayName?: string }>()
-  
-  for (const member of members) {
-    memberDisplayInfo.set(
-      member.inboxId, 
-      getPreferredDisplayInfo({ inboxId: member.inboxId })
-    )
-  }
-  
-  return members.sort((a, b) => {
-    // First preserve admin sort order
-    if (a.permission === "super_admin" && b.permission !== "super_admin") return -1
-    if (a.permission !== "super_admin" && b.permission === "super_admin") return 1
-    if (a.permission === "admin" && b.permission !== "admin") return -1
-    if (a.permission !== "admin" && b.permission === "admin") return 1
-    
-    // Then check for display names
-    const displayInfoA = memberDisplayInfo.get(a.inboxId)
-    const displayInfoB = memberDisplayInfo.get(b.inboxId)
-    
-    const hasNameA = !!(displayInfoA?.displayName && 
-                     displayInfoA.displayName !== a.inboxId && 
-                     !displayInfoA.displayName.startsWith("0x"))
-    const hasNameB = !!(displayInfoB?.displayName && 
-                     displayInfoB.displayName !== b.inboxId && 
-                     !displayInfoB.displayName.startsWith("0x"))
-    
-    if (hasNameA && !hasNameB) return -1
-    if (!hasNameA && hasNameB) return 1
-    
-    // If both have display names, sort alphabetically
-    if (hasNameA && hasNameB) {
-      return displayInfoA!.displayName!.localeCompare(displayInfoB!.displayName!)
+      return a.profile.name!.localeCompare(b.profile.name!)
     }
     
     // Otherwise sort by inboxId for consistency

--- a/features/groups/utils/sort-group-members.ts
+++ b/features/groups/utils/sort-group-members.ts
@@ -3,20 +3,42 @@ import {
   getGroupMemberIsAdmin,
   getGroupMemberIsSuperAdmin,
 } from "@/features/groups/utils/group-admin.utils"
+import { getPreferredDisplayInfo } from "@/features/preferred-display-info/use-preferred-display-info"
 
 export function sortGroupMembers(members: IGroupMember[]) {
+  // Pre-compute all display info first to avoid recalculations during sort
+  const memberDisplayInfo = new Map<string, { displayName?: string }>()
+  
+  for (const member of members) {
+    memberDisplayInfo.set(
+      member.inboxId, 
+      getPreferredDisplayInfo({ inboxId: member.inboxId })
+    )
+  }
+  
   return members.sort((a, b) => {
     const getMemberPriority = (member: IGroupMember): number => {
-      if (getGroupMemberIsSuperAdmin({ member })) return 4
-      if (getGroupMemberIsAdmin({ member })) return 3
-      if (member.consentState === "allowed") return 2
-      if (member.consentState === "denied") return 0
-      return 1
+      const displayInfo = memberDisplayInfo.get(member.inboxId)
+      const hasDisplayName = !!(displayInfo?.displayName && displayInfo.displayName !== member.inboxId && !displayInfo.displayName.startsWith("0x"))
+      
+      // Create a compound priority: admin status (high bits) + display name presence (low bit)
+      if (getGroupMemberIsSuperAdmin({ member })) return hasDisplayName ? 7 : 6
+      if (getGroupMemberIsAdmin({ member })) return hasDisplayName ? 5 : 4
+      return hasDisplayName ? 3 : 0  // Regular members with display names are prioritized
     }
 
     const priorityA = getMemberPriority(a)
     const priorityB = getMemberPriority(b)
 
-    return priorityB - priorityA
+    // First sort by combined priority 
+    if (priorityB !== priorityA) {
+      return priorityB - priorityA
+    }
+    
+    // Then sort alphabetically by display name
+    const displayNameA = memberDisplayInfo.get(a.inboxId)?.displayName || a.inboxId
+    const displayNameB = memberDisplayInfo.get(b.inboxId)?.displayName || b.inboxId
+    
+    return displayNameA.localeCompare(displayNameB)
   })
 }


### PR DESCRIPTION
- Prioritize super admins and admins at the top
- Display members with real names after admins
- Sort alphabetically by display name within each category
- Pre-compute profile info to improve scrolling performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced group member sorting to prioritize admins and members with meaningful display names, improving member list clarity.
  - Added asynchronous profile loading with loading indicators for smoother and more informative group member displays.
  - Improved error handling during profile fetching to ensure reliable member list presentation.
  - Updated group member lists to show loading spinners while data loads and to display members in a consistent, pre-sorted order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->