### PR TITLE
Update to xmtp rn sdk 4.2.0-rc5

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@turnkey/viem": "^0.9.0",
     "@walletconnect/react-native-compat": "^2.19.0",
     "@xmtp/content-type-primitives": "^2.0.0",
-    "@xmtp/react-native-sdk": "4.2.0-dev.73f1217",
+    "@xmtp/react-native-sdk": "4.2.0-rc5",
     "@yornaath/batshit": "^0.10.1",
     "alchemy-sdk": "^3.4.4",
     "amazon-cognito-identity-js": "6.3.12",

--- a/plugins/notification-service-extension/plugin/src/with-my-plugin-ios.ts
+++ b/plugins/notification-service-extension/plugin/src/with-my-plugin-ios.ts
@@ -259,7 +259,7 @@ const withPodfile: ConfigPlugin = (config) => {
 target '${NSE_TARGET_NAME}' do
   # Use the iOS XMTP version required by the installed @xmtp/react-native-sdk
   # Same value that we use in the react-native app
-  pod 'XMTP', '4.2.0-dev.b10e719', :modular_headers => true
+  pod 'XMTP', '4.2.0-rc5', :modular_headers => true
   # Same value that we use in the react-native app
   pod 'MMKV', '~> 2.2.1', :modular_headers => true
   pod 'Sentry/HybridSDK', '8.48.0'

--- a/yarn.lock
+++ b/yarn.lock
@@ -9056,9 +9056,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/react-native-sdk@npm:4.2.0-dev.73f1217":
-  version: 4.2.0-dev.73f1217
-  resolution: "@xmtp/react-native-sdk@npm:4.2.0-dev.73f1217"
+"@xmtp/react-native-sdk@npm:4.2.0-rc5":
+  version: 4.2.0-rc5
+  resolution: "@xmtp/react-native-sdk@npm:4.2.0-rc5"
   dependencies:
     "@changesets/changelog-git": "npm:^0.2.0"
     "@changesets/cli": "npm:^2.27.10"
@@ -9067,13 +9067,12 @@ __metadata:
     "@noble/hashes": "npm:^1.3.3"
     "@xmtp/proto": "npm:3.54.0"
     buffer: "npm:^6.0.3"
-    react-native-performance: "npm:^5.1.2"
     text-encoding: "npm:^0.7.0"
   peerDependencies:
     expo: "*"
     react: "*"
     react-native: "*"
-  checksum: 10c0/e889a618074076ad2c7df50fdc0cc068948662711af9fbb6042d676fcd11473579f5707c255080160a038430bc4a8de9ea727f5b38d27cbf80a8fda105685ded
+  checksum: 10c0/a0504c51547fd8f6af06eeb6c97dd1446dd40f51e463c0f64c622bcf1a639234d711e36c0e70d03d19bee4e904696b1216a6b12952730c6bcb6172b626533905
   languageName: node
   linkType: hard
 
@@ -11065,7 +11064,7 @@ __metadata:
     "@walletconnect/react-native-compat": "npm:^2.19.0"
     "@welldone-software/why-did-you-render": "npm:^8.0.3"
     "@xmtp/content-type-primitives": "npm:^2.0.0"
-    "@xmtp/react-native-sdk": "npm:4.2.0-dev.73f1217"
+    "@xmtp/react-native-sdk": "npm:4.2.0-rc5"
     "@yornaath/batshit": "npm:^0.10.1"
     alchemy-sdk: "npm:^3.4.4"
     amazon-cognito-identity-js: "npm:6.3.12"
@@ -20105,15 +20104,6 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10c0/8ee9a4a63546f92fabd513d38ad0aa02f1e20f3dddfdcafd9356331c0ea77b39e2abe4ca5a26fd5140958e50c10248578930ca21f7169ce702b0693f612eb6c4
-  languageName: node
-  linkType: hard
-
-"react-native-performance@npm:^5.1.2":
-  version: 5.1.2
-  resolution: "react-native-performance@npm:5.1.2"
-  peerDependencies:
-    react-native: "*"
-  checksum: 10c0/a23ad91c5547e0dc62fcdad0230ebd58c8dcfee236174fd2802da14ca3e97451afdba957a9d258e962cfbc4b1671d672547827e096a440ae36b4e967e4a49f50
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Update XMTP React Native SDK from 4.2.0-dev.73f1217 to 4.2.0-rc5 and iOS pod from 4.2.0-dev.b10e719 to 4.2.0-rc5
Updates the `@xmtp/react-native-sdk` dependency version from development version `4.2.0-dev.73f1217` to release candidate `4.2.0-rc5` in [package.json](https://github.com/ephemeraHQ/convos-app/pull/80/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519). Updates the XMTP iOS pod version from `4.2.0-dev.b10e719` to `4.2.0-rc5` in the notification service extension configuration in [with-my-plugin-ios.ts](https://github.com/ephemeraHQ/convos-app/pull/80/files#diff-107b1a4937bce28f6e7144cc84efd9c66f9f39c94945e1f1ec5a411b07688bb4). The [yarn.lock](https://github.com/ephemeraHQ/convos-app/pull/80/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de) file reflects the updated dependency versions.

#### 📍Where to Start
Start with the dependency version change in [package.json](https://github.com/ephemeraHQ/convos-app/pull/80/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to see the main SDK update.

----

_[Macroscope](https://app.macroscope.com) summarized fe94a2e._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the "@xmtp/react-native-sdk" dependency and the iOS XMTP CocoaPod to version 4.2.0-rc5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->