### PR TITLE
Execute logout tasks in background

### DIFF
--- a/features/authentication/use-logout.ts
+++ b/features/authentication/use-logout.ts
@@ -16,7 +16,6 @@ import { useAppStore } from "@/stores/app.store"
 import { captureError } from "@/utils/capture-error"
 import { GenericError } from "@/utils/error"
 import { clearImageCache } from "@/utils/image"
-import { customPromiseAllSettled } from "@/utils/promise-all-settled"
 import { clearReacyQueryQueriesAndCache } from "@/utils/react-query/react-query.utils"
 import { authLogger } from "../../utils/logger/logger"
 
@@ -35,162 +34,138 @@ export const useLogout = () => {
         const hasAtLeastOneSender = senders.length > 0
 
         if (hasAtLeastOneSender) {
-          const [
-            unsubscribeNotificationsResults,
-            streamingResult,
-            unlinkIdentitiesResults,
-            unregisterPushNotificationsResults,
-            unregisterBackgroundTaskResult,
-          ] = await customPromiseAllSettled([
-            // Unsubscribe from conversations notifications
-            Promise.all(
-              senders.map((sender) =>
-                unsubscribeFromAllConversationsNotifications({
-                  clientInboxId: sender.inboxId,
-                }),
-              ),
+          // Fire off all cleanup operations in the background without awaiting
+          // Unsubscribe from conversations notifications
+          void Promise.all(
+            senders.map((sender) =>
+              unsubscribeFromAllConversationsNotifications({
+                clientInboxId: sender.inboxId,
+              }),
             ),
-            // Stop streaming
-            stopStreaming(senders.map((sender) => sender.inboxId)),
-            // Unlink identities from device
-            new Promise<void>(async (resolve, reject) => {
-              try {
-                const currentUser = getCurrentUserQueryData()
-                if (!currentUser) {
-                  // Ignore the flow if we don't have a current user
-                  return resolve()
-                }
-                const currentDevice = await ensureUserDeviceQueryData({
-                  userId: currentUser.id,
-                })
-                const currentUserIdentities = await ensureUserIdentitiesQueryData({
-                  userId: currentUser.id,
-                })
-                await Promise.all(
-                  currentUserIdentities.map((identity) =>
-                    unlinkIdentityFromDeviceMutation({
-                      identityId: identity.id,
-                      deviceId: currentDevice.id,
-                    }),
-                  ),
-                )
-                resolve()
-              } catch (error) {
-                reject(error)
-              }
-            }),
-            // Unregister push notifications
-            Promise.all(
-              senders.map((sender) =>
-                unregisterPushNotifications({ clientInboxId: sender.inboxId }),
-              ),
-            ),
-            // Unregister background sync task
-            unregisterBackgroundSyncTask(),
-          ])
-
-          if (unsubscribeNotificationsResults.status === "rejected") {
+          ).catch((error: unknown) => {
             captureError(
               new GenericError({
-                error: unsubscribeNotificationsResults.reason,
+                error,
                 additionalMessage: "Error unsubscribing from conversations notifications",
               }),
             )
-          }
+          })
 
-          if (streamingResult.status === "rejected") {
+          // Stop streaming
+          void stopStreaming(senders.map((sender) => sender.inboxId)).catch((error: unknown) => {
             captureError(
               new GenericError({
-                error: streamingResult.reason,
+                error,
                 additionalMessage: "Error stopping streaming",
               }),
             )
-          }
+          })
 
-          if (unlinkIdentitiesResults.status === "rejected") {
+          // Unlink identities from device
+          void (async () => {
+            try {
+              const currentUser = getCurrentUserQueryData()
+              if (!currentUser) {
+                return
+              }
+              const currentDevice = await ensureUserDeviceQueryData({
+                userId: currentUser.id,
+              })
+              const currentUserIdentities = await ensureUserIdentitiesQueryData({
+                userId: currentUser.id,
+              })
+              await Promise.all(
+                currentUserIdentities.map((identity) =>
+                  unlinkIdentityFromDeviceMutation({
+                    identityId: identity.id,
+                    deviceId: currentDevice.id,
+                  }),
+                ),
+              )
+            } catch (error) {
+              captureError(
+                new GenericError({
+                  error,
+                  additionalMessage: "Error unlinking identities from device",
+                }),
+              )
+            }
+          })()
+
+          // Unregister push notifications
+          void Promise.all(
+            senders.map((sender) =>
+              unregisterPushNotifications({ clientInboxId: sender.inboxId }),
+            ),
+          ).catch((error: unknown) => {
             captureError(
               new GenericError({
-                error: unlinkIdentitiesResults.reason,
+                error,
                 additionalMessage: "Error unregistering push notifications",
               }),
             )
-          }
+          })
 
-          if (unregisterPushNotificationsResults.status === "rejected") {
+          // Unregister background sync task
+          void unregisterBackgroundSyncTask().catch((error: unknown) => {
             captureError(
               new GenericError({
-                error: unregisterPushNotificationsResults.reason,
-                additionalMessage: "Error unregistering push notifications",
-              }),
-            )
-          }
-
-          if (unregisterBackgroundTaskResult.status === "rejected") {
-            captureError(
-              new GenericError({
-                error: unregisterBackgroundTaskResult.reason,
+                error,
                 additionalMessage: "Error unregistering background sync task",
               }),
             )
-          }
+          })
 
-          try {
-            await Promise.all(
-              senders.map((sender) =>
-                logoutXmtpClient({
-                  inboxId: sender.inboxId,
-                  ethAddress: sender.ethereumAddress,
-                }),
-              ),
-            )
-          } catch (error) {
+          // Logout XMTP clients
+          void Promise.all(
+            senders.map((sender) =>
+              logoutXmtpClient({
+                inboxId: sender.inboxId,
+                ethAddress: sender.ethereumAddress,
+              }),
+            ),
+          ).catch((error: unknown) => {
             captureError(new GenericError({ error, additionalMessage: "Error logging out xmtp" }))
-          }
+          })
         }
 
-        try {
-          await clearTurnkeySessions()
-        } catch (error) {
+        // Clear Turnkey sessions in the background
+        void clearTurnkeySessions().catch((error: unknown) => {
           captureError(
             new GenericError({ error, additionalMessage: "Error clearing turnkey sessions" }),
           )
-        }
+        })
 
-        // Doing this at the end because we want to make sure that we cleared everything before showing auth screen
+        // Clear image cache in the background
+        void clearImageCache().catch((error: unknown) => {
+          captureError(
+            new GenericError({
+              error,
+              additionalMessage: "Error clearing image cache after logout",
+            }),
+          )
+        })
+
+        // Immediately proceed with setting auth status and clearing stores
         useAuthenticationStore.getState().actions.setStatus("signedOut")
-
-        // This needs to be at the end because at many places we use useSafeCurrentSender()
-        // and it will throw error if we reset the store too early
-        // Need the setTimeout because for some reason the navigation is not updated immediately when we set auth status to signed out
         useMultiInboxStore.getState().actions.reset()
-
         useNotificationsStore.getState().actions.reset()
-
-        // Might want to only clear certain queries later but okay for now
-        // Put this last because otherwise some useQuery hook triggers even tho we're logging out
         clearReacyQueryQueriesAndCache()
 
-        authLogger.debug("Successfully logged out")
+        authLogger.debug("Successfully initiated logout")
+
+        // Give a small delay before hiding the overlay to ensure smooth transition
+        setTimeout(() => {
+          useAppStore.getState().actions.setIsShowingFullScreenOverlay(false)
+          useAppStore.getState().actions.setIsLoggingOut(false)
+        }, 500)
       } catch (error) {
+        useAppStore.getState().actions.setIsShowingFullScreenOverlay(false)
+        useAppStore.getState().actions.setIsLoggingOut(false)
         throw new GenericError({
           error,
           additionalMessage: "Error logging out",
         })
-      } finally {
-        // Clear expo-image cache after logout for privacy and to avoid stale images
-        try {
-          await clearImageCache()
-        } catch (e) {
-          captureError(
-            new GenericError({
-              error: e,
-              additionalMessage: "Error clearing image cache after logout",
-            }),
-          )
-        }
-
-        useAppStore.getState().actions.setIsShowingFullScreenOverlay(false)
-        useAppStore.getState().actions.setIsLoggingOut(false)
       }
     },
     [clearTurnkeySessions],


### PR DESCRIPTION
I refactored the `logout` function within `features/authentication/use-logout.ts` to execute cleanup operations in the background, without waiting for their completion.

Here's what I changed:

*   I removed the `await` keyword from all asynchronous cleanup operations, including calls to `unsubscribeFromAllConversationsNotifications`, `stopStreaming`, `unlinkIdentityFromDeviceMutation`, `unregisterPushNotifications`, `unregisterBackgroundSyncTask`, `logoutXmtpClient`, and `clearTurnkeySessions`. This allows these tasks to run in parallel without blocking the main thread.
*   I removed the `customPromiseAllSettled` utility, as individual promises are now fired off independently.
*   I introduced the `void` operator before each background promise (e.g., `void Promise.all(...)`, `void stopStreaming(...)`). This explicitly signals that the promise's return value is intentionally not awaited or handled directly, preventing linting warnings about unhandled promises while clearly stating the "fire-and-forget" intent.
*   I implemented individual `.catch()` blocks for each background operation. This ensures that any errors occurring during these non-blocking tasks are still captured and logged via `captureError`, maintaining error visibility without blocking the logout flow.
*   I moved the `clearImageCache` call from the `finally` block into the `try` block and made it a background operation using `void`.
*   I adjusted the order of operations to prioritize immediate user feedback. State updates like setting the authentication status to "signedOut" (`useAuthenticationStore.getState().actions.setStatus("signedOut")`) and resetting various stores (`useMultiInboxStore`, `useNotificationsStore`, `clearReacyQueryQueriesAndCache`) now occur immediately after the background tasks are initiated, providing a faster perceived logout experience.
*   I added a `setTimeout` with a 500ms delay before hiding the full-screen overlay and setting `isLoggingOut` to `false`. This ensures a smoother visual transition for the user, preventing an abrupt disappearance of the loading state.

The outcome is a significantly faster and more responsive logout process, as the user is immediately signed out while resource cleanup continues efficiently in the background. Errors from background tasks are still logged, ensuring operational visibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the logout process for better performance and reliability, ensuring all cleanup tasks run in the background with enhanced error handling.
  - Added a short delay after logout to provide a smoother transition when hiding the full-screen overlay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->