### PR TITLE
Update to xmtp rn sdk 4.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@turnkey/viem": "^0.9.0",
     "@walletconnect/react-native-compat": "^2.19.0",
     "@xmtp/content-type-primitives": "^2.0.0",
-    "@xmtp/react-native-sdk": "^4.2.0",
+    "@xmtp/react-native-sdk": "^4.2.3",
     "@yornaath/batshit": "^0.10.1",
     "alchemy-sdk": "^3.4.4",
     "amazon-cognito-identity-js": "6.3.12",

--- a/plugins/notification-service-extension/plugin/src/with-my-plugin-ios.ts
+++ b/plugins/notification-service-extension/plugin/src/with-my-plugin-ios.ts
@@ -259,7 +259,7 @@ const withPodfile: ConfigPlugin = (config) => {
 target '${NSE_TARGET_NAME}' do
   # Use the iOS XMTP version required by the installed @xmtp/react-native-sdk
   # Same value that we use in the react-native app
-  pod 'XMTP', '4.2.0', :modular_headers => true
+  pod 'XMTP', '4.2.1', :modular_headers => true
   # Same value that we use in the react-native app
   pod 'MMKV', '~> 2.2.1', :modular_headers => true
   pod 'Sentry/HybridSDK', '8.48.0'

--- a/yarn.lock
+++ b/yarn.lock
@@ -8934,9 +8934,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/react-native-sdk@npm:^4.2.0":
-  version: 4.2.2
-  resolution: "@xmtp/react-native-sdk@npm:4.2.2"
+"@xmtp/react-native-sdk@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "@xmtp/react-native-sdk@npm:4.2.3"
   dependencies:
     "@changesets/changelog-git": "npm:^0.2.0"
     "@changesets/cli": "npm:^2.27.10"
@@ -8950,7 +8950,7 @@ __metadata:
     expo: "*"
     react: "*"
     react-native: "*"
-  checksum: 10c0/0eed089ec01ebc3530a9100fdeaedf0265a1d4dc74746f00b3fc6ed727e7625ebc5d02d80dd3e1abd121fcfe2cd055f30fdee1601e592f101c6b8d1a0db0899b
+  checksum: 10c0/ae6d4d83606898d8b5b109da68c1cb77c041040e80ee1ee4915d386672b03a2d8958cb36ae5de29499517f7659ba2120383a7afa008bcdbef83621bd5f0545be
   languageName: node
   linkType: hard
 
@@ -10861,7 +10861,7 @@ __metadata:
     "@walletconnect/react-native-compat": "npm:^2.19.0"
     "@welldone-software/why-did-you-render": "npm:^8.0.3"
     "@xmtp/content-type-primitives": "npm:^2.0.0"
-    "@xmtp/react-native-sdk": "npm:^4.2.0"
+    "@xmtp/react-native-sdk": "npm:^4.2.3"
     "@yornaath/batshit": "npm:^0.10.1"
     alchemy-sdk: "npm:^3.4.4"
     amazon-cognito-identity-js: "npm:6.3.12"


### PR DESCRIPTION
### Update XMTP React Native SDK dependency from version 4.2.0 to 4.2.3 and iOS pod from 4.2.0 to 4.2.1
Updates the `@xmtp/react-native-sdk` package dependency version and corresponding iOS pod version across the project configuration files.

- Updates `@xmtp/react-native-sdk` dependency from ^4.2.0 to ^4.2.3 in [package.json](https://github.com/ephemeraHQ/convos-app/pull/87/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519)
- Updates XMTP pod version from 4.2.0 to 4.2.1 in iOS notification service extension configuration in [with-my-plugin-ios.ts](https://github.com/ephemeraHQ/convos-app/pull/87/files#diff-107b1a4937bce28f6e7144cc84efd9c66f9f39c94945e1f1ec5a411b07688bb4)
- Updates dependency resolution information in [yarn.lock](https://github.com/ephemeraHQ/convos-app/pull/87/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de)

#### 📍Where to Start
Start with the dependency version change in [package.json](https://github.com/ephemeraHQ/convos-app/pull/87/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to understand the main SDK update.

----

_[Macroscope](https://app.macroscope.com) summarized 68a83ff._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the `@xmtp/react-native-sdk` dependency to version 4.2.3.
  - Updated the XMTP CocoaPod dependency for iOS notification service extension to version 4.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->