### PR TITLE
Fixed typo

### DIFF
--- a/design-system/Icon/Icon.tsx
+++ b/design-system/Icon/Icon.tsx
@@ -3,7 +3,7 @@ import { useAppTheme } from "@/theme/use-app-theme"
 import { logger } from "@/utils/logger/logger"
 import { IIconName, IIconProps } from "./Icon.types"
 
-// For now we don't have tpying for SFSymbols but we use a 1-1 with the key name
+// For now we don't have typing for SFSymbols but we use a 1-1 with the key name
 export const iconRegistry: Record<IIconName, SFSymbol> = {
   xmark: "xmark",
   "xmark.circle.fill": "xmark.circle.fill",


### PR DESCRIPTION
### Fix typo in comment within Icon component
Corrects a spelling error in a comment within [Icon.tsx](https://github.com/ephemeraHQ/convos-app/pull/89/files#diff-8c2038fce3bd74bee38a149f5544c160990e897516826f5cfbcc93efd0d45bc2), changing 'tpying' to 'typing' in the comment about SFSymbols.

#### 📍Where to Start
Start with the comment correction in [Icon.tsx](https://github.com/ephemeraHQ/convos-app/pull/89/files#diff-8c2038fce3bd74bee38a149f5544c160990e897516826f5cfbcc93efd0d45bc2).

----

_[Macroscope](https://app.macroscope.com) summarized 53c9b6b._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Fixed a typo in a comment to improve code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->