### PR TITLE
Bump to xmtp 4.3.0-rc1

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@turnkey/viem": "^0.9.0",
     "@walletconnect/react-native-compat": "^2.19.0",
     "@xmtp/content-type-primitives": "^2.0.0",
-    "@xmtp/react-native-sdk": "^4.2.5",
+    "@xmtp/react-native-sdk": "^4.3.0-rc1",
     "@yornaath/batshit": "^0.10.1",
     "alchemy-sdk": "^3.4.4",
     "amazon-cognito-identity-js": "6.3.12",

--- a/plugins/notification-service-extension/plugin/src/with-my-plugin-ios.ts
+++ b/plugins/notification-service-extension/plugin/src/with-my-plugin-ios.ts
@@ -259,7 +259,7 @@ const withPodfile: ConfigPlugin = (config) => {
 target '${NSE_TARGET_NAME}' do
   # Use the iOS XMTP version required by the installed @xmtp/react-native-sdk
   # Same value that we use in the react-native app
-  pod 'XMTP', '4.2.3', :modular_headers => true
+  pod 'XMTP', '4.3.0-rc1', :modular_headers => true
   # Same value that we use in the react-native app
   pod 'MMKV', '~> 2.2.1', :modular_headers => true
   pod 'Sentry/HybridSDK', '8.48.0'

--- a/yarn.lock
+++ b/yarn.lock
@@ -8934,9 +8934,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/react-native-sdk@npm:^4.2.5":
-  version: 4.2.5
-  resolution: "@xmtp/react-native-sdk@npm:4.2.5"
+"@xmtp/react-native-sdk@npm:^4.3.0-rc1":
+  version: 4.3.0-rc1
+  resolution: "@xmtp/react-native-sdk@npm:4.3.0-rc1"
   dependencies:
     "@changesets/changelog-git": "npm:^0.2.0"
     "@changesets/cli": "npm:^2.27.10"
@@ -8950,7 +8950,7 @@ __metadata:
     expo: "*"
     react: "*"
     react-native: "*"
-  checksum: 10c0/c7941bf473e114c3153095444b80c22da6485ff6d7c4222604af0c04b01c5629076eb72757d6f60e82e7c4c11209ba304f2cbf6cabe1082123870943ead41a01
+  checksum: 10c0/6edab420702c23db74d456eed4ea1f2d0c9b66ef93ddf387650bf1534f51408ad321a029e9c157d686674ab1b8d3e4210fe742fe3d10dcaba1f0ed9264460ea7
   languageName: node
   linkType: hard
 
@@ -10861,7 +10861,7 @@ __metadata:
     "@walletconnect/react-native-compat": "npm:^2.19.0"
     "@welldone-software/why-did-you-render": "npm:^8.0.3"
     "@xmtp/content-type-primitives": "npm:^2.0.0"
-    "@xmtp/react-native-sdk": "npm:^4.2.5"
+    "@xmtp/react-native-sdk": "npm:^4.3.0-rc1"
     "@yornaath/batshit": "npm:^0.10.1"
     alchemy-sdk: "npm:^3.4.4"
     amazon-cognito-identity-js: "npm:6.3.12"


### PR DESCRIPTION
### Bump XMTP React Native SDK and iOS pod dependency to version 4.3.0-rc1
Updates the `@xmtp/react-native-sdk` dependency from version 4.2.5 to 4.3.0-rc1 in [package.json](https://github.com/ephemeraHQ/convos-app/pull/90/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) and aligns the iOS pod dependency version for `XMTP` from 4.2.3 to 4.3.0-rc1 in the notification service extension configuration in [with-my-plugin-ios.ts](https://github.com/ephemeraHQ/convos-app/pull/90/files#diff-107b1a4937bce28f6e7144cc84efd9c66f9f39c94945e1f1ec5a411b07688bb4). The [yarn.lock](https://github.com/ephemeraHQ/convos-app/pull/90/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de) file reflects the updated dependency tree and integrity hashes for the version changes.

#### 📍Where to Start
Start with the dependency version change in [package.json](https://github.com/ephemeraHQ/convos-app/pull/90/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to understand the primary SDK update.

----

_[Macroscope](https://app.macroscope.com) summarized 42b3d3a._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `@xmtp/react-native-sdk` dependency to version 4.3.0-rc1.
  * Updated the XMTP CocoaPod version for the iOS notification service extension to 4.3.0-rc1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->