### PR TITLE
Release 1.3RC2

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@turnkey/viem": "^0.9.0",
     "@walletconnect/react-native-compat": "^2.19.0",
     "@xmtp/content-type-primitives": "^2.0.0",
-    "@xmtp/react-native-sdk": "^4.3.0-rc1",
+    "@xmtp/react-native-sdk": "^4.3.0-rc2",
     "@yornaath/batshit": "^0.10.1",
     "alchemy-sdk": "^3.4.4",
     "amazon-cognito-identity-js": "6.3.12",

--- a/plugins/notification-service-extension/plugin/src/with-my-plugin-ios.ts
+++ b/plugins/notification-service-extension/plugin/src/with-my-plugin-ios.ts
@@ -259,7 +259,7 @@ const withPodfile: ConfigPlugin = (config) => {
 target '${NSE_TARGET_NAME}' do
   # Use the iOS XMTP version required by the installed @xmtp/react-native-sdk
   # Same value that we use in the react-native app
-  pod 'XMTP', '4.3.0-rc1', :modular_headers => true
+  pod 'XMTP', '4.3.0-rc2', :modular_headers => true
   # Same value that we use in the react-native app
   pod 'MMKV', '~> 2.2.1', :modular_headers => true
   pod 'Sentry/HybridSDK', '8.48.0'

--- a/yarn.lock
+++ b/yarn.lock
@@ -8934,9 +8934,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/react-native-sdk@npm:^4.3.0-rc1":
-  version: 4.3.0-rc1
-  resolution: "@xmtp/react-native-sdk@npm:4.3.0-rc1"
+"@xmtp/react-native-sdk@npm:^4.3.0-rc2":
+  version: 4.3.0-rc2
+  resolution: "@xmtp/react-native-sdk@npm:4.3.0-rc2"
   dependencies:
     "@changesets/changelog-git": "npm:^0.2.0"
     "@changesets/cli": "npm:^2.27.10"
@@ -8950,7 +8950,7 @@ __metadata:
     expo: "*"
     react: "*"
     react-native: "*"
-  checksum: 10c0/6edab420702c23db74d456eed4ea1f2d0c9b66ef93ddf387650bf1534f51408ad321a029e9c157d686674ab1b8d3e4210fe742fe3d10dcaba1f0ed9264460ea7
+  checksum: 10c0/857a494fd3478d67c9bcfe06cc04b90e99c6aa5820a8296a2eeaefc4fbf003e151abbb68bac0b76aa52ddfd1189daf7201b4a1f434a0c4934d369a53b927e31f
   languageName: node
   linkType: hard
 
@@ -10861,7 +10861,7 @@ __metadata:
     "@walletconnect/react-native-compat": "npm:^2.19.0"
     "@welldone-software/why-did-you-render": "npm:^8.0.3"
     "@xmtp/content-type-primitives": "npm:^2.0.0"
-    "@xmtp/react-native-sdk": "npm:^4.3.0-rc1"
+    "@xmtp/react-native-sdk": "npm:^4.3.0-rc2"
     "@yornaath/batshit": "npm:^0.10.1"
     alchemy-sdk: "npm:^3.4.4"
     amazon-cognito-identity-js: "npm:6.3.12"


### PR DESCRIPTION
### Update XMTP React Native SDK and iOS pod dependency from version 4.3.0-rc1 to 4.3.0-rc2 for release 1.3RC2
This pull request updates the `@xmtp/react-native-sdk` dependency version in [package.json](https://github.com/ephemeraHQ/convos-app/pull/91/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) and the corresponding iOS pod dependency version in the notification service extension configuration file [with-my-plugin-ios.ts](https://github.com/ephemeraHQ/convos-app/pull/91/files#diff-107b1a4937bce28f6e7144cc84efd9c66f9f39c94945e1f1ec5a411b07688bb4). The [yarn.lock](https://github.com/ephemeraHQ/convos-app/pull/91/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de) file reflects these dependency version changes.

#### 📍Where to Start
Start with the dependency version change in [package.json](https://github.com/ephemeraHQ/convos-app/pull/91/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to understand the primary dependency update.

----

_[Macroscope](https://app.macroscope.com) summarized fccf087._