### PR TITLE
Bump sdk release to 4.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@turnkey/viem": "^0.9.0",
     "@walletconnect/react-native-compat": "^2.19.0",
     "@xmtp/content-type-primitives": "^2.0.0",
-    "@xmtp/react-native-sdk": "^4.4.0-dev.7f5d8e0",
+    "@xmtp/react-native-sdk": "4.3.4",
     "@yornaath/batshit": "^0.10.1",
     "alchemy-sdk": "^3.4.4",
     "amazon-cognito-identity-js": "6.3.12",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@turnkey/viem": "^0.9.0",
     "@walletconnect/react-native-compat": "^2.19.0",
     "@xmtp/content-type-primitives": "^2.0.0",
-    "@xmtp/react-native-sdk": "4.3.4",
+    "@xmtp/react-native-sdk": "4.3.5",
     "@yornaath/batshit": "^0.10.1",
     "alchemy-sdk": "^3.4.4",
     "amazon-cognito-identity-js": "6.3.12",

--- a/plugins/notification-service-extension/plugin/src/with-my-plugin-ios.ts
+++ b/plugins/notification-service-extension/plugin/src/with-my-plugin-ios.ts
@@ -259,7 +259,7 @@ const withPodfile: ConfigPlugin = (config) => {
 target '${NSE_TARGET_NAME}' do
   # Use the iOS XMTP version required by the installed @xmtp/react-native-sdk
   # Same value that we use in the react-native app
-  pod 'XMTP', '4.4.0-dev.7f5d8e0.c2ccb07', :modular_headers => true
+  pod 'XMTP', '4.3.4', :modular_headers => true
   # Same value that we use in the react-native app
   pod 'MMKV', '~> 2.2.1', :modular_headers => true
   pod 'Sentry/HybridSDK', '8.48.0'

--- a/plugins/notification-service-extension/plugin/src/with-my-plugin-ios.ts
+++ b/plugins/notification-service-extension/plugin/src/with-my-plugin-ios.ts
@@ -259,7 +259,7 @@ const withPodfile: ConfigPlugin = (config) => {
 target '${NSE_TARGET_NAME}' do
   # Use the iOS XMTP version required by the installed @xmtp/react-native-sdk
   # Same value that we use in the react-native app
-  pod 'XMTP', '4.3.4', :modular_headers => true
+  pod 'XMTP', '4.3.5', :modular_headers => true
   # Same value that we use in the react-native app
   pod 'MMKV', '~> 2.2.1', :modular_headers => true
   pod 'Sentry/HybridSDK', '8.48.0'

--- a/yarn.lock
+++ b/yarn.lock
@@ -8934,9 +8934,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/react-native-sdk@npm:4.3.4":
-  version: 4.3.4
-  resolution: "@xmtp/react-native-sdk@npm:4.3.4"
+"@xmtp/react-native-sdk@npm:4.3.5":
+  version: 4.3.5
+  resolution: "@xmtp/react-native-sdk@npm:4.3.5"
   dependencies:
     "@changesets/changelog-git": "npm:^0.2.0"
     "@changesets/cli": "npm:^2.27.10"
@@ -8950,7 +8950,7 @@ __metadata:
     expo: "*"
     react: "*"
     react-native: "*"
-  checksum: 10c0/edc2b4d360a03f48157f776e96f6ef583fb23665887f951ebff24d2ba1bc9286e9a077429c5fa927c32d72e8bffe587751e555a6b67ab1a7ab19240ef5aaccf6
+  checksum: 10c0/d3e46974a2367d461bc92a6fbf714ac77f5b3c538bd4fb7870e09de68c69ea62798f8804cc0651b9f2423875e26b50fa65bf9e3bf8845b7ec5aba35b68e3306a
   languageName: node
   linkType: hard
 
@@ -10861,7 +10861,7 @@ __metadata:
     "@walletconnect/react-native-compat": "npm:^2.19.0"
     "@welldone-software/why-did-you-render": "npm:^8.0.3"
     "@xmtp/content-type-primitives": "npm:^2.0.0"
-    "@xmtp/react-native-sdk": "npm:4.3.4"
+    "@xmtp/react-native-sdk": "npm:4.3.5"
     "@yornaath/batshit": "npm:^0.10.1"
     alchemy-sdk: "npm:^3.4.4"
     amazon-cognito-identity-js: "npm:6.3.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8934,9 +8934,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/react-native-sdk@npm:^4.4.0-dev.7f5d8e0":
-  version: 4.4.0-dev.7f5d8e0
-  resolution: "@xmtp/react-native-sdk@npm:4.4.0-dev.7f5d8e0"
+"@xmtp/react-native-sdk@npm:4.3.4":
+  version: 4.3.4
+  resolution: "@xmtp/react-native-sdk@npm:4.3.4"
   dependencies:
     "@changesets/changelog-git": "npm:^0.2.0"
     "@changesets/cli": "npm:^2.27.10"
@@ -8950,7 +8950,7 @@ __metadata:
     expo: "*"
     react: "*"
     react-native: "*"
-  checksum: 10c0/8498734dbff04253ae0fcb43776eaea5644a4190a455b80685b126e0567c26a38b58cad6e3d4fc458928d71c483ed89ca88399aca88511cc02c8f683ad14b94a
+  checksum: 10c0/edc2b4d360a03f48157f776e96f6ef583fb23665887f951ebff24d2ba1bc9286e9a077429c5fa927c32d72e8bffe587751e555a6b67ab1a7ab19240ef5aaccf6
   languageName: node
   linkType: hard
 
@@ -10861,7 +10861,7 @@ __metadata:
     "@walletconnect/react-native-compat": "npm:^2.19.0"
     "@welldone-software/why-did-you-render": "npm:^8.0.3"
     "@xmtp/content-type-primitives": "npm:^2.0.0"
-    "@xmtp/react-native-sdk": "npm:^4.4.0-dev.7f5d8e0"
+    "@xmtp/react-native-sdk": "npm:4.3.4"
     "@yornaath/batshit": "npm:^0.10.1"
     alchemy-sdk: "npm:^3.4.4"
     amazon-cognito-identity-js: "npm:6.3.12"


### PR DESCRIPTION
### Bump XMTP SDK version from 4.4.0-dev.7f5d8e0 to 4.3.5 in React Native dependencies and iOS Pod configuration
This pull request updates the XMTP SDK version across multiple configuration files:

- Updates `@xmtp/react-native-sdk` dependency from `^4.4.0-dev.7f5d8e0` to `4.3.5` in [package.json](https://github.com/ephemeraHQ/convos-app/pull/94/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519)
- Updates XMTP CocoaPod version from `4.4.0-dev.7f5d8e0.c2ccb07` to `4.3.5` in [with-my-plugin-ios.ts](https://github.com/ephemeraHQ/convos-app/pull/94/files#diff-107b1a4937bce28f6e7144cc84efd9c66f9f39c94945e1f1ec5a411b07688bb4)
- Regenerates lockfile entries in [yarn.lock](https://github.com/ephemeraHQ/convos-app/pull/94/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de) to align with the updated SDK version

#### 📍Where to Start
Start with the dependency version change in [package.json](https://github.com/ephemeraHQ/convos-app/pull/94/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to understand the primary SDK version update.

----

_[Macroscope](https://app.macroscope.com) summarized b756c8e._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the "@xmtp/react-native-sdk" and "XMTP" dependencies to stable release versions for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->